### PR TITLE
Refactoring of Routes, separating search and resource operations.

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaId.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaId.scala
@@ -18,6 +18,9 @@ import scala.util.{Failure, Try}
   * @param version  the version of the schema
   */
 final case class SchemaId(domainId: DomainId, name: String, version: Version) {
+  /**
+    * Extracts the [[SchemaName]] from the current [[SchemaId]].
+    */
   def schemaName: SchemaName = SchemaName(domainId, name)
 }
 

--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaId.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaId.scala
@@ -17,10 +17,12 @@ import scala.util.{Failure, Try}
   * @param name     the name of the schema
   * @param version  the version of the schema
   */
-final case class SchemaId(domainId: DomainId, name: String, version: Version)
+final case class SchemaId(domainId: DomainId, name: String, version: Version) {
+  def schemaName: SchemaName = SchemaName(domainId, name)
+}
 
 object SchemaId {
-  final val regex: Regex = s"""${DomainId.regex.regex}/([a-zA-Z0-9]+)/v([0-9]+)\\.([0-9]+)\\.([0-9]+)""".r
+  final val regex: Regex = s"""${SchemaName.regex.regex}/v([0-9]+)\\.([0-9]+)\\.([0-9]+)""".r
 
   /**
     * Attempts to parse the argument string into a ''SchemaId''.
@@ -37,8 +39,8 @@ object SchemaId {
       Failure(new IllegalArgumentException("Unable to decode value into a SchemaId"))
   }
 
-  final implicit def schemaIdShow(implicit D: Show[DomainId], V: Show[Version]): Show[SchemaId] = Show.show { id =>
-    s"${id.domainId.show}/${id.name}/${id.version.show}"
+  final implicit def schemaIdShow(implicit D: Show[SchemaName], V: Show[Version]): Show[SchemaId] = Show.show { id =>
+    s"${id.schemaName.show}/${id.version.show}"
   }
 
   final implicit def schemaIdEncoder(implicit S: Show[SchemaId]): Encoder[SchemaId] =

--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaName.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaName.scala
@@ -1,0 +1,38 @@
+package ch.epfl.bluebrain.nexus.kg.core.schemas
+
+import cats.Show
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.common.types.Version
+import ch.epfl.bluebrain.nexus.kg.core.domains.DomainId
+import ch.epfl.bluebrain.nexus.kg.core.organizations.OrgId
+
+import scala.util.matching.Regex
+
+/**
+  * Unique schema name identifier rooted in a domain.
+  *
+  * @param domainId the domain identifier for this schema
+  * @param name     the name of the schema
+=  */
+final case class SchemaName(domainId: DomainId, name: String) {
+  def versioned(version: Version): SchemaId = SchemaId(domainId, name, version)
+}
+
+object SchemaName {
+  final val regex: Regex = s"""${DomainId.regex.regex}/([a-zA-Z0-9]+)""".r
+
+  /**
+    * Attempts to parse the argument string into a ''SchemaName''.
+    *
+    * @param string the string representation of the schema name.
+    * @return either a ''Some[SchemaName]'' if the string matches the expected format or a ''None'' otherwise
+    */
+  final def apply(string: String): Option[SchemaName] = string match {
+    case regex(org, dom, name) => Some(SchemaName(DomainId(OrgId(org), dom), name))
+    case _                     => None
+  }
+
+  final implicit def schemaNameShow(implicit D: Show[DomainId]): Show[SchemaName] = Show.show { name =>
+    s"${name.domainId.show}/${name.name}"
+  }
+}

--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaName.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaName.scala
@@ -13,8 +13,13 @@ import scala.util.matching.Regex
   *
   * @param domainId the domain identifier for this schema
   * @param name     the name of the schema
-=  */
+  *                 =*/
 final case class SchemaName(domainId: DomainId, name: String) {
+  /**
+    * Constructs a [[SchemaId]] from a the current [[SchemaName]] with a provided ''version''.
+    *
+    * @param version the version of the schema
+    */
   def versioned(version: Version): SchemaId = SchemaId(domainId, name, version)
 }
 

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaIdSpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaIdSpec.scala
@@ -16,6 +16,10 @@ class SchemaIdSpec extends WordSpecLike with Matchers with Inspectors {
     val schemaId = SchemaId(domId, "name", Version(1, 2, 3))
     val schemaIdString = """"org/dom/name/v1.2.3""""
 
+    "extract an schemaName properly" in {
+      schemaId.schemaName shouldEqual SchemaName(domId, "name")
+    }
+
     "be encoded properly into json" in {
       schemaId.asJson.noSpaces shouldEqual schemaIdString
     }

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaNameSpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/kg/core/schemas/SchemaNameSpec.scala
@@ -1,0 +1,24 @@
+package ch.epfl.bluebrain.nexus.kg.core.schemas
+
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.common.types.Version
+import ch.epfl.bluebrain.nexus.kg.core.domains.DomainId
+import ch.epfl.bluebrain.nexus.kg.core.organizations.OrgId
+import org.scalatest.{Inspectors, Matchers, WordSpecLike}
+
+class SchemaNameSpec extends WordSpecLike with Matchers with Inspectors {
+
+  "A SchemaName" should {
+    val domId = DomainId(OrgId("org"), "dom")
+    val schemaName = SchemaName(domId, "name")
+
+    "have a proper string representation" in {
+      schemaName.show shouldEqual s"org/dom/name"
+    }
+
+    "be properly converted into a schemaId with a provided version" in {
+      val version = Version(1,0,0)
+      schemaName.versioned(version) shouldEqual SchemaId(domId, "name", version)
+    }
+  }
+}

--- a/modules/indexing/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/Qualifier.scala
+++ b/modules/indexing/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/Qualifier.scala
@@ -8,7 +8,7 @@ import cats.syntax.show._
 import ch.epfl.bluebrain.nexus.kg.core.domains.DomainId
 import ch.epfl.bluebrain.nexus.kg.core.instances.InstanceId
 import ch.epfl.bluebrain.nexus.kg.core.organizations.OrgId
-import ch.epfl.bluebrain.nexus.kg.core.schemas.SchemaId
+import ch.epfl.bluebrain.nexus.kg.core.schemas.{SchemaId, SchemaName}
 import ch.epfl.bluebrain.nexus.kg.core.schemas.shapes.ShapeId
 
 import scala.util.Try
@@ -169,6 +169,11 @@ trait QualifierInstances {
 
     override def unapply(uri: Uri, base: Uri): Option[OrgId] =
       Try { OrgId(removeBaseUri(uri, base, Some("organizations"))) }.toOption
+  }
+
+  implicit val schemaNameQualifier: Qualifier[SchemaName] = new Qualifier[SchemaName] {
+    override def apply(value: SchemaName, base: Uri) = Uri(s"$base/schemas/${value.show}")
+    override def unapply(uri: Uri, base: Uri) = SchemaName(removeBaseUri(uri, base, Some("schemas")))
   }
 
   implicit val schemaIdQualifier: Qualifier[SchemaId] = new Qualifier[SchemaId] {

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/directives/PathDirectives.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/directives/PathDirectives.scala
@@ -1,10 +1,18 @@
 package ch.epfl.bluebrain.nexus.kg.service.directives
 
-import akka.http.scaladsl.server.{Directive1, ValidationRejection}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.PathMatchers.Segment
+import akka.http.scaladsl.server.{Directive1, ValidationRejection}
 import ch.epfl.bluebrain.nexus.common.types.Version
+import ch.epfl.bluebrain.nexus.kg.core.domains.DomainId
+import ch.epfl.bluebrain.nexus.kg.core.instances.InstanceId
+import ch.epfl.bluebrain.nexus.kg.core.organizations.OrgId
+import ch.epfl.bluebrain.nexus.kg.core.schemas.{SchemaId, SchemaName}
 import ch.epfl.bluebrain.nexus.kg.service.routes.CommonRejections.IllegalVersionFormat
+import shapeless.ops.coproduct.Selector
+import shapeless.{:+:, CNil, Coproduct}
+
+import scala.annotation.implicitNotFound
 
 /**
   * Collection of path specific directives.
@@ -19,11 +27,75 @@ trait PathDirectives {
     pathPrefix(Segment).flatMap { versionString =>
       Version(versionString) match {
         case None          =>
-          reject(new ValidationRejection("Illegal version format", Some(IllegalVersionFormat("Illegal version format"))))
+          reject(ValidationRejection("Illegal version format", Some(IllegalVersionFormat("Illegal version format"))))
         case Some(version) =>
           provide(version)
       }
     }
+
+  type ResourceId = InstanceId :+: SchemaId :+: SchemaName :+: DomainId :+: OrgId :+: None.type :+: CNil
+  type ResourceIdSelector[A] = Selector[ResourceId, A]
+
+  /**
+    * Extracts all the choices of ''resourceId''s from the path parameter
+    * with the expected API structure: {org}/{domain}/{schema_name}/{schema_version}/{instance_uuid}
+    *
+    * @param max the maximum number of [[Segment]] to be consumed
+    */
+  def extractAnyResourceId(max: Int = 5): Directive1[ResourceId] =
+    pathPrefix(Segments(0, max)).flatMap {
+      case Nil                                            => provide(Coproduct[ResourceId](None))
+      case org :: Nil                                     => provide(Coproduct[ResourceId](OrgId(org)))
+      case org :: dom :: Nil                              => provide(Coproduct[ResourceId](DomainId(OrgId(org), dom)))
+      case org :: dom :: schema :: Nil                    => provide(Coproduct[ResourceId](SchemaName(DomainId(OrgId(org), dom), schema)))
+      case org :: dom :: schema :: version :: Nil         => Version(version) match {
+        case Some(ver) =>
+          provide(Coproduct[ResourceId](SchemaId(DomainId(OrgId(org), dom), schema, ver)))
+        case None      =>
+          reject(ValidationRejection("Illegal version format", Some(IllegalVersionFormat("Illegal version format"))))
+      }
+      case org :: dom :: schema :: version :: uuid :: Nil => Version(version) match {
+        case Some(ver) =>
+          provide(Coproduct[ResourceId](InstanceId(SchemaId(DomainId(OrgId(org), dom), schema, ver), uuid)))
+        case None      =>
+          reject(ValidationRejection("Illegal version format", Some(IllegalVersionFormat("Illegal version format"))))
+      }
+      case _                                              => reject
+    }
+
+
+  /**
+    * Summons a [[ResourceIdSelector]] instance from the implicit scope.
+    *
+    * @param sel the implicitly available [[ResourceIdSelector]] for the generic type ''A''
+    * @tparam A the resourceId to be extracted. It which should be one of the types in [[ResourceId]] Coproduct
+    */
+  @implicitNotFound("The type param ${A} needs to be one of ['InstanceId', 'SchemaId', 'SchemaName', 'DomainId', 'OrgId', 'None.type']")
+  def of[A](implicit sel: ResourceIdSelector[A]): ResourceIdSelector[A] = sel
+
+  /**
+    * Extracts the resourceId of type ''A'' from the choices generated in ''resourceId''.
+    *
+    * @param resourceId the choices for each type in [[ResourceId]]
+    * @param selector   the selector for the type ''A''
+    * @tparam A the resourceId to be extracted. It which should be one of the types in [[ResourceId]] Coproduct
+    */
+  def resourceId[A](resourceId: ResourceId, selector: ResourceIdSelector[A]): Directive1[A] =
+    resourceId.select[A](selector) match {
+      case Some(a) => provide(a)
+      case None    => reject
+    }
+
+  /**
+    * Extracts the resourceId of type ''A'' from the choices generated in ''extractAnyResourceId''.
+    *
+    * @param selector the selector for the type ''A''
+    * @tparam A the resourceId to be extracted. It which should be one of the types in [[ResourceId]] Coproduct
+    */
+  def extractResourceId[A](depth: Int, selector: ResourceIdSelector[A]): Directive1[A] = {
+    extractAnyResourceId(depth).
+      flatMap(id => resourceId(id, selector))
+  }
 }
 
 object PathDirectives extends PathDirectives

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/DefaultRouteHandling.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/DefaultRouteHandling.scala
@@ -1,0 +1,26 @@
+package ch.epfl.bluebrain.nexus.kg.service.routes
+
+import akka.http.scaladsl.server.Directives.{handleExceptions, handleRejections, pathPrefix}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.RouteConcatenation._
+
+trait DefaultRouteHandling {
+
+  protected def resourceRoutes: Route
+
+  protected def searchRoutes: Route
+
+  /**
+    * Combining ''resourceRoutes'' with ''searchRoutes''
+    * and add rejection and exception handling to it.
+    *
+    * @param initialPrefix the initial prefix to be consumed
+    */
+  def combinedRoutesFor(initialPrefix: String): Route = handleExceptions(ExceptionHandling.exceptionHandler) {
+    handleRejections(RejectionHandling.rejectionHandler) {
+      pathPrefix(initialPrefix) {
+        resourceRoutes ~ searchRoutes
+      }
+    }
+  }
+}

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/InstanceRoutes.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/InstanceRoutes.scala
@@ -101,17 +101,21 @@ class InstanceRoutes(
               }
             }
           } ~
-          (get & traceName("getInstance")) {
+          get {
             parameter('rev.as[Long].?) {
               case Some(rev) =>
-                onSuccess(instances.fetch(instanceId, rev)) {
-                  case Some(instance) => complete(StatusCodes.OK -> instance)
-                  case None           => complete(StatusCodes.NotFound)
+                traceName("getInstanceRevision") {
+                  onSuccess(instances.fetch(instanceId, rev)) {
+                    case Some(instance) => complete(StatusCodes.OK -> instance)
+                    case None           => complete(StatusCodes.NotFound)
+                  }
                 }
               case None      =>
-                onSuccess(instances.fetch(instanceId)) {
-                  case Some(instance) => complete(StatusCodes.OK -> instance)
-                  case None           => complete(StatusCodes.NotFound)
+                traceName("getInstance") {
+                  onSuccess(instances.fetch(instanceId)) {
+                    case Some(instance) => complete(StatusCodes.OK -> instance)
+                    case None           => complete(StatusCodes.NotFound)
+                  }
                 }
             }
           } ~

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/InstanceRoutes.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/InstanceRoutes.scala
@@ -12,7 +12,7 @@ import ch.epfl.bluebrain.nexus.commons.sparql.client.SparqlClient
 import ch.epfl.bluebrain.nexus.kg.core.domains.DomainId
 import ch.epfl.bluebrain.nexus.kg.core.instances.{Instance, InstanceId, InstanceRef, Instances}
 import ch.epfl.bluebrain.nexus.kg.core.organizations.OrgId
-import ch.epfl.bluebrain.nexus.kg.core.schemas.SchemaId
+import ch.epfl.bluebrain.nexus.kg.core.schemas.{SchemaId, SchemaName}
 import ch.epfl.bluebrain.nexus.kg.indexing.Qualifier._
 import ch.epfl.bluebrain.nexus.kg.indexing.filtering.FilteringSettings
 import ch.epfl.bluebrain.nexus.kg.indexing.query.builder.FilterQueries
@@ -44,145 +44,116 @@ import scala.concurrent.{ExecutionContext, Future}
 class InstanceRoutes(
   instances: Instances[Future, Source[ByteString, Any], Source[ByteString, Future[IOResult]]],
   instanceQueries: FilterQueries[Future, InstanceId],
-  base: Uri)(implicit querySettings: QuerySettings, filteringSettings: FilteringSettings) {
+  base: Uri)(implicit querySettings: QuerySettings, filteringSettings: FilteringSettings)
+  extends DefaultRouteHandling {
 
   private val encoders = new InstanceCustomEncoders(base)
+
   import encoders._
 
-  def routes: Route = handleExceptions(ExceptionHandling.exceptionHandler) {
-    handleRejections(RejectionHandling.rejectionHandler) {
-      pathPrefix("data") {
-        (pathEndOrSingleSlash & get & searchQueryParams) { (pagination, filterOpt, termOpt, deprecatedOpt) =>
-          traceName("searchInstances") {
-            val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
-            instanceQueries.list(filter, pagination, termOpt).buildResponse(base, pagination)
+  protected def searchRoutes: Route =
+    (get & searchQueryParams) { (pagination, filterOpt, termOpt, deprecatedOpt) =>
+      val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
+      traceName("searchInstances") {
+        pathEndOrSingleSlash {
+          instanceQueries.list(filter, pagination, termOpt).buildResponse(base, pagination)
+        } ~
+        extractAnyResourceId() { id =>
+          (pathEndOrSingleSlash & resourceId(id, of[OrgId])) { orgId =>
+            instanceQueries.list(orgId, filter, pagination, termOpt).buildResponse(base, pagination)
+          } ~
+            (pathEndOrSingleSlash & resourceId(id, of[DomainId])) { domainId =>
+            instanceQueries.list(domainId, filter, pagination, termOpt).buildResponse(base, pagination)
+          } ~
+          (pathEndOrSingleSlash & resourceId(id, of[SchemaName])) { case SchemaName(domainId, name) =>
+            instanceQueries.list(domainId, name, filter, pagination, termOpt).buildResponse(base, pagination)
+          } ~
+          (pathEndOrSingleSlash & resourceId(id, of[SchemaId])) { schemaId =>
+            instanceQueries.list(schemaId, filter, pagination, termOpt).buildResponse(base, pagination)
+          } ~
+          (resourceId(id, of[InstanceId]) & pathPrefix("outgoing") & pathEndOrSingleSlash) { instanceId =>
+            instanceQueries.outgoing(instanceId, filter, pagination, termOpt).buildResponse(base, pagination)
+          } ~
+          (resourceId(id, of[InstanceId]) & pathPrefix("incoming") & pathEndOrSingleSlash) { instanceId =>
+            instanceQueries.incoming(instanceId, filter, pagination, termOpt).buildResponse(base, pagination)
+          }
+        }
+      }
+    }
+
+  protected def resourceRoutes: Route =
+    extractAnyResourceId() { id =>
+      (pathEndOrSingleSlash & post & resourceId(id, of[SchemaId])) { schemaId =>
+        entity(as[Json]) { json =>
+          traceName("createInstance") {
+            onSuccess(instances.create(schemaId, json)) { ref =>
+              complete(StatusCodes.Created -> ref)
+            }
+          }
+        }
+      } ~
+      resourceId(id, of[InstanceId]) { instanceId =>
+        pathEndOrSingleSlash {
+          (put & entity(as[Json]) & parameter('rev.as[Long])) { (json, rev) =>
+            traceName("updateInstance") {
+              onSuccess(instances.update(instanceId, rev, json)) { ref =>
+                complete(StatusCodes.OK -> ref)
+              }
+            }
+          } ~
+          (get & traceName("getInstance")) {
+            parameter('rev.as[Long].?) {
+              case Some(rev) =>
+                onSuccess(instances.fetch(instanceId, rev)) {
+                  case Some(instance) => complete(StatusCodes.OK -> instance)
+                  case None           => complete(StatusCodes.NotFound)
+                }
+              case None      =>
+                onSuccess(instances.fetch(instanceId)) {
+                  case Some(instance) => complete(StatusCodes.OK -> instance)
+                  case None           => complete(StatusCodes.NotFound)
+                }
+            }
+          } ~
+          (delete & parameter('rev.as[Long])) { rev =>
+            traceName("deprecateInstance") {
+              onSuccess(instances.deprecate(instanceId, rev)) { ref =>
+                complete(StatusCodes.OK -> ref)
+              }
+            }
           }
         } ~
-        pathPrefix(Segment) { orgIdString =>
-          val orgId = OrgId(orgIdString)
-          (pathEndOrSingleSlash & get & searchQueryParams) { (pagination, filterOpt, termOpt, deprecatedOpt) =>
-            traceName("searchInstancesOfOrg") {
-              val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
-              instanceQueries.list(orgId, filter, pagination, termOpt).buildResponse(base, pagination)
+        path("attachment") {
+          (put & parameter('rev.as[Long])) { rev =>
+            fileUpload("file") {
+              case (metadata, byteSource) =>
+                traceName("createInstanceAttachment") {
+                  onSuccess(instances.createAttachment(instanceId, rev, metadata.fileName, metadata.contentType.value, byteSource)) { info =>
+                    complete(StatusCodes.Created -> info)
+                  }
+                }
             }
-
           } ~
-          pathPrefix(Segment) { domain =>
-            val domainId = DomainId(orgId, domain)
-            (pathEndOrSingleSlash & get & searchQueryParams) { (pagination, filterOpt, termOpt, deprecatedOpt) =>
-                traceName("searchInstancesOfDomain") {
-                  val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
-                  instanceQueries.list(domainId, filter, pagination, termOpt).buildResponse(base, pagination)
+          (delete & parameter('rev.as[Long])) { rev =>
+            traceName("removeInstanceAttachment") {
+              onSuccess(instances.removeAttachment(instanceId, rev)) { ref =>
+                complete(StatusCodes.OK -> ref)
+              }
+            }
+          } ~
+          get {
+            parameter('rev.as[Long].?) { revOpt =>
+              traceName("getInstanceAttachment") {
+                val result = revOpt match {
+                  case Some(rev) => instances.fetchAttachment(instanceId, rev)
+                  case None      => instances.fetchAttachment(instanceId)
                 }
-            } ~
-            pathPrefix(Segment) { name =>
-              (pathEndOrSingleSlash & get & searchQueryParams) { (pagination, filterOpt, termOpt, deprecatedOpt) =>
-                traceName("searchInstancesOfSchemaName") {
-                  val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
-                  instanceQueries.list(domainId, name, filter, pagination, termOpt).buildResponse(base, pagination)
-                }
-              } ~
-              versioned.apply { version =>
-                val schemaId = SchemaId(DomainId(orgId, domain), name, version)
-                (pathEndOrSingleSlash & get & searchQueryParams) { (pagination, filterOpt, termOpt, deprecatedOpt) =>
-                  traceName("searchInstancesOfSchema") {
-                    val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
-                    instanceQueries.list(schemaId, filter, pagination, termOpt).buildResponse(base, pagination)
-                  }
-                } ~
-                (pathEndOrSingleSlash & post) {
-                  entity(as[Json]) { json =>
-                    traceName("createInstance") {
-                      onSuccess(instances.create(schemaId, json)) { ref =>
-                        complete(StatusCodes.Created -> ref)
-                      }
-                    }
-                  }
-                } ~
-                pathPrefix(Segment) { id =>
-                  val instanceId = InstanceId(schemaId, id)
-                  (pathPrefix("outgoing") & pathEndOrSingleSlash & get) {
-                    searchQueryParams.apply { (pagination, filterOpt, termOpt, deprecatedOpt) =>
-                      val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
-                      instanceQueries.outgoing(instanceId, filter, pagination, termOpt).buildResponse(base, pagination)
-                    }
-                  } ~
-                  (pathPrefix("incoming") & pathEndOrSingleSlash & get) {
-                    searchQueryParams.apply { (pagination, filterOpt, termOpt, deprecatedOpt) =>
-                      val filter = filterFrom(deprecatedOpt, filterOpt, querySettings.nexusVocBase)
-                      instanceQueries.incoming(instanceId, filter, pagination, termOpt).buildResponse(base, pagination)
-                    }
-                  } ~
-                  pathEndOrSingleSlash {
-                    (put & entity(as[Json]) & parameter('rev.as[Long])) { (json, rev) =>
-                      traceName("updateInstance") {
-                        onSuccess(instances.update(instanceId, rev, json)) { ref =>
-                          complete(StatusCodes.OK -> ref)
-                        }
-                      }
-                    } ~
-                    get {
-                      parameter('rev.as[Long].?) {
-                        case Some(rev) =>
-                          traceName("getInstanceRevision") {
-                            onSuccess(instances.fetch(instanceId, rev)) {
-                              case Some(instance) => complete(StatusCodes.OK -> instance)
-                              case None           => complete(StatusCodes.NotFound)
-                            }
-                          }
-                        case None      =>
-                          traceName("getInstance") {
-                            onSuccess(instances.fetch(instanceId)) {
-                              case Some(instance) => complete(StatusCodes.OK -> instance)
-                              case None           => complete(StatusCodes.NotFound)
-                            }
-                          }
-                      }
-                    } ~
-                    (delete & parameter('rev.as[Long])) { rev =>
-                      traceName("deprecateInstance") {
-                        onSuccess(instances.deprecate(instanceId, rev)) { ref =>
-                          complete(StatusCodes.OK -> ref)
-                        }
-                      }
-                    }
-                  } ~
-                  path("attachment") {
-                    (put & parameter('rev.as[Long])) { rev =>
-                      fileUpload("file") {
-                        case (metadata, byteSource) =>
-                          traceName("createInstanceAttachment") {
-                            onSuccess(instances.createAttachment(instanceId, rev, metadata.fileName, metadata.contentType.value, byteSource)) { info =>
-                              complete(StatusCodes.Created -> info)
-                            }
-                          }
-                      }
-                    } ~
-                    (delete & parameter('rev.as[Long])) { rev =>
-                      traceName("removeInstanceAttachment") {
-                        onSuccess(instances.removeAttachment(instanceId, rev)) { ref =>
-                          complete(StatusCodes.OK -> ref)
-                        }
-                      }
-                    } ~
-                    get {
-                      parameter('rev.as[Long].?) { maybeRev =>
-                        traceName("getInstanceAttachment") {
-                          val result = maybeRev match {
-                            case Some(rev) => instances.fetchAttachment(instanceId, rev)
-                            case None      => instances.fetchAttachment(instanceId)
-                          }
-                          onSuccess(result) {
-                            case Some((info, source)) =>
-                              val ct = ContentType.parse(info.contentType).getOrElse(ContentTypes.`application/octet-stream`)
-                              complete(HttpEntity(ct, info.size.value, source))
-                            case None                 =>
-                              complete(StatusCodes.NotFound)
-                          }
-                        }
-                      }
-                    }
-                  }
+                onSuccess(result) {
+                  case Some((info, source)) =>
+                    val ct = ContentType.parse(info.contentType).getOrElse(ContentTypes.`application/octet-stream`)
+                    complete(HttpEntity(ct, info.size.value, source))
+                  case None                 =>
+                    complete(StatusCodes.NotFound)
                 }
               }
             }
@@ -190,9 +161,9 @@ class InstanceRoutes(
         }
       }
     }
-  }
-}
 
+  def routes: Route = combinedRoutesFor("data")
+}
 object InstanceRoutes {
 
   /**
@@ -239,5 +210,4 @@ private class InstanceCustomEncoders(base: Uri)(implicit le: Encoder[Link]) exte
         le(Link(rel = "schema", href = instanceId.schemaId.qualifyAsString))
       ))
   }
-
 }

--- a/modules/service/src/test/scala/ch/epfl/bluebrain/nexus/kg/service/directives/PathDirectivesSpec.scala
+++ b/modules/service/src/test/scala/ch/epfl/bluebrain/nexus/kg/service/directives/PathDirectivesSpec.scala
@@ -1,0 +1,76 @@
+package ch.epfl.bluebrain.nexus.kg.service.directives
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.epfl.bluebrain.nexus.kg.indexing.Qualifier
+import ch.epfl.bluebrain.nexus.kg.indexing.Qualifier._
+import ch.epfl.bluebrain.nexus.kg.service.directives.PathDirectives._
+import ch.epfl.bluebrain.nexus.kg.service.routes.CommonRejections.IllegalVersionFormat
+import ch.epfl.bluebrain.nexus.kg.service.routes.Error.classNameOf
+import ch.epfl.bluebrain.nexus.kg.service.routes.{Error, ExceptionHandling, RejectionHandling}
+import org.scalatest.{Matchers, WordSpecLike}
+import shapeless.Poly1
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.generic.auto._
+
+class PathDirectivesSpec extends WordSpecLike with ScalatestRouteTest with Matchers {
+
+  object completeWithType extends Poly1 {
+    implicit def caseNone: Case.Aux[None.type, Route] = at[None.type] { _ =>
+      complete("none")
+    }
+    implicit def caseDefault[A: Qualifier]: Case.Aux[A, Route] = at[A] { a =>
+      complete(a.qualifyAsStringWith(""))
+    }
+  }
+
+  private val route = {
+    (handleExceptions(ExceptionHandling.exceptionHandler) & handleRejections(RejectionHandling.rejectionHandler)) {
+      extractAnyResourceId() { id =>
+        id.fold(completeWithType)
+      }
+    }
+  }
+
+  "An extractResourceId directive" should {
+    "match with None for /" in {
+      Get("/") ~> route ~> check {
+        responseAs[String] shouldEqual "none"
+      }
+    }
+    "match with OrgId" in {
+      Get("/org") ~> route ~> check {
+        responseAs[String] shouldEqual "/organizations/org"
+      }
+    }
+    "match with DomainId" in {
+      Get("/org/dom") ~> route ~> check {
+        responseAs[String] shouldEqual "/organizations/org/domains/dom"
+      }
+    }
+    "match with SchemaName" in {
+      Get("/org/dom/name") ~> route ~> check {
+        responseAs[String] shouldEqual "/schemas/org/dom/name"
+      }
+    }
+    "match with SchemaId" in {
+      Get("/org/dom/name/v1.0.0") ~> route ~> check {
+        responseAs[String] shouldEqual "/schemas/org/dom/name/v1.0.0"
+      }
+    }
+    "match with InstanceId" in {
+      Get("/org/dom/name/v1.0.0/uuid") ~> route ~> check {
+        responseAs[String] shouldEqual "/data/org/dom/name/v1.0.0/uuid"
+      }
+    }
+    "reject the request with an IllegalVersionFormat" in {
+      Get("/org/dom/name/v1.0/uuid") ~> route ~> check {
+        status shouldEqual StatusCodes.BadRequest
+        responseAs[Error].code shouldEqual classNameOf[IllegalVersionFormat.type]
+      }
+    }
+  }
+
+}

--- a/modules/service/src/test/scala/ch/epfl/bluebrain/nexus/kg/service/routes/InstanceRoutesSpec.scala
+++ b/modules/service/src/test/scala/ch/epfl/bluebrain/nexus/kg/service/routes/InstanceRoutesSpec.scala
@@ -257,6 +257,24 @@ class InstanceRoutesSpec(blazegraphPort: Int)
         }
       }
 
+    "return list of instances" in new Context  {
+      indexInstances()
+      Get(s"/data?deprecated=false") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        val results = responseAs[Results]
+        results.total shouldEqual 5L
+        results.results.size shouldEqual 5
+        forAll(results.results.zipWithIndex) { case(result, idx) =>
+          val schema = s"$baseUri/schemas/${schemaId.copy(version = Version(idx,0,0)).show}"
+          val id = s"$schema/${baseUUID}0$idx".replace("/schemas/", "/data/")
+          result shouldEqual Result(id,
+            Source(id,List(Link("self", id),Link("schema", schema))))
+        }
+        results.links should contain allElementsOf
+          List(Link("self", s"$base/data?deprecated=false"))
+      }
+    }
+
     "return list of instances from domain id with specific pagination" in new Context  {
       indexInstances()
       val specificPagination = Pagination(0L, 5)

--- a/modules/service/src/test/scala/ch/epfl/bluebrain/nexus/kg/service/routes/SchemaRoutesSpec.scala
+++ b/modules/service/src/test/scala/ch/epfl/bluebrain/nexus/kg/service/routes/SchemaRoutesSpec.scala
@@ -113,6 +113,13 @@ class SchemaRoutesSpec
       }
     }
 
+    "return list of schemas" in {
+      Get(s"/schemas") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        responseAs[Results] shouldEqual fixedListSchemas(Uri("http://localhost/schemas"))
+      }
+    }
+
     "return list of schemas from organization" in {
       Get(s"/schemas/org") ~> route ~> check {
         status shouldEqual StatusCodes.OK


### PR DESCRIPTION
- Added a PathDirectives which allows to extract any resourceIds
- using the expected API structure {org}/{dom}/{name}/{ver}/{uuid}.
- Added SchemaName case class needed to represent that endpoint.