### PR TITLE
Customize Akka HTTP connection pool config.

### DIFF
--- a/modules/service/src/main/resources/application.conf
+++ b/modules/service/src/main/resources/application.conf
@@ -5,7 +5,16 @@ include "sparql.conf"
 include "kamon.conf"
 
 akka {
-  http.server.parsing.max-content-length = 10g
+
+  http {
+    server.parsing.max-content-length = 10g
+    host-connection-pool  {
+      max-connections   = 16
+      max-connections   = ${?AKKA_HTTP_MAX_CONNECTIONS}
+      max-open-requests = 64
+      max-open-requests = ${?AKKA_HTTP_MAX_OPEN_REQUESTS}
+    }
+  }
 
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"


### PR DESCRIPTION
Current defaults for Akka http config are too low (only 4 open connections per host), especially for for connecting to Blazegraph.