### PR TITLE
Add search and distribution contexts to responses

### DIFF
--- a/modules/indexing/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/query/QueryResults.scala
+++ b/modules/indexing/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/query/QueryResults.scala
@@ -89,7 +89,7 @@ object QueryResults {
     * @param maxScore   the maximum score of the individual query results
     * @param results    the collection of results
     * @tparam A generic type of the response's payload
-    * @return an socred instance of [[QueryResults]]
+    * @return an scored instance of [[QueryResults]]
     */
   final def apply[A](total: Long, maxScore: Float, results: List[QueryResult[A]]): QueryResults[A] =
     new ScoredQueryResults[A](total, maxScore, results)

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/io/BaseEncoder.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/io/BaseEncoder.scala
@@ -30,6 +30,11 @@ class BaseEncoder(prefixes: PrefixUris) {
     def addSearchContext: Json = addContext(prefixes.SearchContext)
 
     /**
+      * Adds or merges the distribution (i.e. attachment) context URI to an existing JSON object.
+      */
+    def addDistributionContext: Json = addContext(prefixes.DistributionContext)
+
+    /**
       * Adds or merges a context URI to an existing JSON object.
       *
       * @param context the standard context URI

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/io/RoutesEncoder.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/io/RoutesEncoder.scala
@@ -3,12 +3,15 @@ package ch.epfl.bluebrain.nexus.kg.service.io
 import akka.http.scaladsl.model.Uri
 import ch.epfl.bluebrain.nexus.kg.core.Ref
 import ch.epfl.bluebrain.nexus.kg.indexing.Qualifier._
+import ch.epfl.bluebrain.nexus.kg.indexing.query.QueryResult
 import ch.epfl.bluebrain.nexus.kg.indexing.query.QueryResult.{ScoredQueryResult, UnscoredQueryResult}
+import ch.epfl.bluebrain.nexus.kg.indexing.query.QueryResults.ScoredQueryResults
 import ch.epfl.bluebrain.nexus.kg.indexing.{ConfiguredQualifier, Qualifier}
 import ch.epfl.bluebrain.nexus.kg.service.config.Settings.PrefixUris
 import ch.epfl.bluebrain.nexus.kg.service.hateoas.Links
 import ch.epfl.bluebrain.nexus.kg.service.io.RoutesEncoder.linksEncoder
 import ch.epfl.bluebrain.nexus.kg.service.io.RoutesEncoder.JsonLDKeys._
+import ch.epfl.bluebrain.nexus.kg.service.query.LinksQueryResults
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
 
@@ -80,6 +83,35 @@ abstract class RoutesEncoder[Id, Reference, Entity](base: Uri, prefixes: PrefixU
       )
     }
 
+  implicit def linksQueryResultsEncoder(implicit E: Encoder[QueryResult[Id]]): Encoder[LinksQueryResults[Id]] =
+    Encoder.encodeJson.contramap { response =>
+      val json = Json.obj(
+        total   -> Json.fromLong(response.response.total),
+        results -> Json.fromValues(response.response.results.map(E.apply)),
+        links   -> linksWithContextEncoder(response.links)
+      )
+      response.response match {
+        case ScoredQueryResults(_, ms, _) =>
+          json.deepMerge(Json.obj(maxScore -> Json.fromFloatOrNull(ms))).addSearchContext
+        case _ => json.addSearchContext
+      }
+    }
+
+  implicit def linksQueryResultsEntityEncoder(
+      implicit E: Encoder[QueryResult[Entity]]): Encoder[LinksQueryResults[Entity]] =
+    Encoder.encodeJson.contramap { response =>
+      val json = Json.obj(
+        total   -> Json.fromLong(response.response.total),
+        results -> Json.fromValues(response.response.results.map(E.apply)),
+        links   -> linksWithContextEncoder(response.links)
+      )
+      response.response match {
+        case ScoredQueryResults(_, ms, _) =>
+          json.deepMerge(Json.obj(maxScore -> Json.fromFloatOrNull(ms))).addSearchContext
+        case _ => json.addSearchContext
+      }
+    }
+
   private def selfLink(id: Id): Links = Links("self" -> id.qualify)
 
 }
@@ -99,8 +131,12 @@ object RoutesEncoder {
     val `@id`          = "@id"
     val links          = "links"
     val resultId       = "resultId"
+    val results        = "results"
     val source         = "source"
     val score          = "score"
+    val total          = "total"
+    val maxScore       = "maxScore"
+    val distribution   = "distribution"
     val nxvNs          = "nxv"
     val nxvRev         = "nxv:rev"
     val nxvDeprecated  = "nxv:deprecated"

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/ContextRoutes.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/ContextRoutes.scala
@@ -67,7 +67,7 @@ class ContextRoutes(contexts: Contexts[Future],
   private implicit val _ = (entity: Context) => entity.id
   private implicit val sQualifier: ConfiguredQualifier[String] =
     Qualifier.configured[String](querySettings.nexusVocBase)
-  private val contextEncoders = new ContextCustomEncoders(base, prefixes)
+  private implicit val contextEncoders: ContextCustomEncoders = new ContextCustomEncoders(base, prefixes)
   import contextEncoders._
 
   private val exceptionHandler = ExceptionHandling.exceptionHandler

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/DomainRoutes.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/DomainRoutes.scala
@@ -52,8 +52,8 @@ final class DomainRoutes(domains: Domains[Future],
                                                orderedKeys: OrderedKeys)
     extends DefaultRouteHandling {
 
-  private implicit val _ = (entity: Domain) => entity.id
-  private val encoders   = new DomainCustomEncoders(base, prefixes)
+  private implicit val _                              = (entity: Domain) => entity.id
+  private implicit val encoders: DomainCustomEncoders = new DomainCustomEncoders(base, prefixes)
   import encoders._
 
   protected def searchRoutes(implicit credentials: Option[OAuth2BearerToken]): Route =

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/OrganizationRoutes.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/OrganizationRoutes.scala
@@ -50,8 +50,8 @@ final class OrganizationRoutes(orgs: Organizations[Future],
                                                      orderedKeys: OrderedKeys)
     extends DefaultRouteHandling {
 
-  private implicit val _ = (entity: Organization) => entity.id
-  private val encoders   = new OrgCustomEncoders(base, prefixes)
+  private implicit val _                           = (entity: Organization) => entity.id
+  private implicit val encoders: OrgCustomEncoders = new OrgCustomEncoders(base, prefixes)
   import encoders._
 
   protected def searchRoutes(implicit credentials: Option[OAuth2BearerToken]): Route =

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/SchemaRoutes.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/SchemaRoutes.scala
@@ -66,8 +66,8 @@ class SchemaRoutes(schemas: Schemas[Future],
   private implicit val sQualifier: ConfiguredQualifier[String] =
     Qualifier.configured[String](querySettings.nexusVocBase)
 
-  private val schemaEncoders = new SchemaCustomEncoders(base, prefixes)
-  private val shapeEncoders  = new ShapeCustomEncoders(base, prefixes)
+  private implicit val schemaEncoders: SchemaCustomEncoders = new SchemaCustomEncoders(base, prefixes)
+  private val shapeEncoders                                 = new ShapeCustomEncoders(base, prefixes)
 
   import schemaEncoders._
   import shapeEncoders.shapeEncoder

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/SearchResponse.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/kg/service/routes/SearchResponse.scala
@@ -10,10 +10,10 @@ import ch.epfl.bluebrain.nexus.kg.indexing.pagination.Pagination
 import ch.epfl.bluebrain.nexus.kg.indexing.query.QueryResult.{ScoredQueryResult, UnscoredQueryResult}
 import ch.epfl.bluebrain.nexus.kg.indexing.query.{QueryResult, QueryResults}
 import ch.epfl.bluebrain.nexus.kg.service.hateoas.Links
+import ch.epfl.bluebrain.nexus.kg.service.io.BaseEncoder
 import ch.epfl.bluebrain.nexus.kg.service.io.PrinterSettings._
 import ch.epfl.bluebrain.nexus.kg.service.query.LinksQueryResults
 import io.circe.Encoder
-import io.circe.generic.auto._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -25,9 +25,10 @@ trait SearchResponse {
   implicit class QueryResultsOpts[Id](qr: Future[QueryResults[Id]]) {
 
     private[routes] def addPagination(base: Uri, pagination: Pagination)(implicit
-                                                                         L: Encoder[Links],
                                                                          R: Encoder[UnscoredQueryResult[Id]],
                                                                          S: Encoder[ScoredQueryResult[Id]],
+                                                                         L: Encoder[Links],
+                                                                         B: BaseEncoder,
                                                                          orderedKeys: OrderedKeys): Route = {
       extract(_.request.uri) { uri =>
         onSuccess(qr) { result =>
@@ -49,11 +50,12 @@ trait SearchResponse {
         implicit
         f: Id => Future[Option[Entity]],
         ec: ExecutionContext,
-        L: Encoder[Links],
         R: Encoder[UnscoredQueryResult[Id]],
         S: Encoder[ScoredQueryResult[Id]],
         Re: Encoder[UnscoredQueryResult[Entity]],
         Se: Encoder[ScoredQueryResult[Entity]],
+        L: Encoder[Links],
+        B: BaseEncoder,
         orderedKeys: OrderedKeys): Route = {
       if (fields.contains("all")) {
         qr.flatMap { q =>

--- a/modules/tests/src/test/scala/ch/epfl/bluebrain/nexus/kg/tests/integration/BootstrapIntegrationSpec.scala
+++ b/modules/tests/src/test/scala/ch/epfl/bluebrain/nexus/kg/tests/integration/BootstrapIntegrationSpec.scala
@@ -17,6 +17,7 @@ import ch.epfl.bluebrain.nexus.kg.core.organizations.{OrgId, Organization}
 import ch.epfl.bluebrain.nexus.kg.core.schemas.{Schema, SchemaId}
 import ch.epfl.bluebrain.nexus.kg.indexing.{ConfiguredQualifier, Qualifier}
 import ch.epfl.bluebrain.nexus.kg.service.config.Settings.PrefixUris
+import ch.epfl.bluebrain.nexus.kg.service.io.BaseEncoder
 import ch.epfl.bluebrain.nexus.kg.service.routes.SchemaRoutes.SchemaConfig
 import ch.epfl.bluebrain.nexus.kg.service.routes._
 import io.circe._
@@ -60,11 +61,12 @@ abstract class BootstrapIntegrationSpec(apiUri: Uri, prefixes: PrefixUris)(impli
   private implicit val contextIdExtractor             = (entity: Context) => entity.id
   private implicit val instanceIdExtractor            = (entity: Instance) => entity.id
 
-  val orgsEncoders     = new OrgCustomEncoders(apiUri, prefixes)
-  val domsEncoders     = new DomainCustomEncoders(apiUri, prefixes)
-  val contextEncoders  = new ContextCustomEncoders(apiUri, prefixes)
-  val schemaEncoders   = new SchemaCustomEncoders(apiUri, prefixes)
-  val instanceEncoders = new InstanceCustomEncoders(apiUri, prefixes)
+  val orgsEncoders                      = new OrgCustomEncoders(apiUri, prefixes)
+  val domsEncoders                      = new DomainCustomEncoders(apiUri, prefixes)
+  val contextEncoders                   = new ContextCustomEncoders(apiUri, prefixes)
+  val schemaEncoders                    = new SchemaCustomEncoders(apiUri, prefixes)
+  val instanceEncoders                  = new InstanceCustomEncoders(apiUri, prefixes)
+  implicit val baseEncoder: BaseEncoder = instanceEncoders
 }
 
 object BootstrapIntegrationSpec extends Randomness with Resources {


### PR DESCRIPTION
- Add search context
- Move attachment metadata to 'distribution' field in response, with its own context