### PR TITLE
Fix scaladocs for ElasticIds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -246,5 +246,5 @@ lazy val kamonDeps = Seq(
   "org.aspectj" % "aspectjweaver"          % "1.8.10" % Runtime
 )
 
-addCommandAlias("review", ";clean;coverage;scapegoat;test;coverageReport;coverageAggregate")
+addCommandAlias("review", ";clean;coverage;scapegoat;test;coverageReport;coverageAggregate;doc")
 addCommandAlias("rel", ";release with-defaults skip-tests")

--- a/modules/elastic/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/ElasticIds.scala
+++ b/modules/elastic/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/ElasticIds.scala
@@ -67,7 +67,6 @@ object ElasticIds {
     * Interface syntax to expose new functionality into the generic type A
     *
     * @param id   the instance of ''A''
-    * @param ev$1 the implicitly available ''Show[A]''
     * @param T    the implicitly available ''Typeable[A]''
     * @tparam A the generic type
     */


### PR DESCRIPTION
and `doc` to `review` task, so that it gets caught during review rather than when releasing.