### PR TITLE
Refactored routes in order to make them more comprehensive

### DIFF
--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/Main.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/Main.scala
@@ -29,6 +29,7 @@ import ch.epfl.bluebrain.nexus.kg.resources.{Repo, Resources}
 import ch.epfl.bluebrain.nexus.kg.routes.{Clients, ResourcesRoutes, ServiceDescriptionRoutes}
 import ch.epfl.bluebrain.nexus.service.http.directives.PrefixDirectives._
 import ch.epfl.bluebrain.nexus.sourcing.akka.{ShardingAggregate, SourcingAkkaSettings}
+import com.github.jsonldjava.core.DocumentLoader
 import com.typesafe.config.ConfigFactory
 import io.circe.Json
 import io.circe.generic.auto._
@@ -101,7 +102,7 @@ object Main {
     val serviceDesc                = ServiceDescriptionRoutes(appConfig.description).routes
 
     val logger = Logging(as, getClass)
-
+    System.setProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING, "true")
     cluster.registerOnMemberUp {
       logger.info("==== Cluster is Live ====")
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/Main.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/Main.scala
@@ -26,7 +26,7 @@ import ch.epfl.bluebrain.nexus.kg.resources.Repo.Agg
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.AttachmentStore
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.AttachmentStore.{AkkaIn, AkkaOut}
 import ch.epfl.bluebrain.nexus.kg.resources.{Repo, Resources}
-import ch.epfl.bluebrain.nexus.kg.routes.{Clients, ResourceRoutes, ServiceDescriptionRoutes}
+import ch.epfl.bluebrain.nexus.kg.routes.{Clients, ResourcesRoutes, ServiceDescriptionRoutes}
 import ch.epfl.bluebrain.nexus.service.http.directives.PrefixDirectives._
 import ch.epfl.bluebrain.nexus.sourcing.akka.{ShardingAggregate, SourcingAkkaSettings}
 import com.typesafe.config.ConfigFactory
@@ -96,7 +96,7 @@ object Main {
     implicit val saToken           = appConfig.iam.serviceAccountToken
     implicit val projectResolution = ProjectResolution.task(cache, clients.adminClient)
     val resources: Resources[Task] = Resources[Task]
-    val resourceRoutes             = ResourceRoutes(resources).routes
+    val resourceRoutes             = new ResourcesRoutes(resources).routes
     val apiRoutes                  = uriPrefix(appConfig.http.publicUri)(resourceRoutes)
     val serviceDesc                = ServiceDescriptionRoutes(appConfig.description).routes
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
@@ -11,6 +11,7 @@ import ch.epfl.bluebrain.nexus.iam.client.types.AuthToken
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig._
 import ch.epfl.bluebrain.nexus.kg.config.Contexts._
 import ch.epfl.bluebrain.nexus.kg.config.Schemas._
+import ch.epfl.bluebrain.nexus.service.kamon.directives.TracingDirectives
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -186,6 +187,8 @@ object AppConfig {
       "_rev",
       "_deprecated"
     ))
+
+  val tracing = new TracingDirectives()
 
   implicit def toSparql(implicit appConfig: AppConfig): SparqlConfig           = appConfig.sparql
   implicit def toElastic(implicit appConfig: AppConfig): ElasticConfig         = appConfig.elastic

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
@@ -64,6 +64,7 @@ private[routes] class ResourceRoutes(resources: Resources[Task], schema: Absolut
 
   def transformCreate(j: Json): Json = j
 
+  @SuppressWarnings(Array("UnusedMethodParameter"))
   def transformUpdate(@silent id: AbsoluteIri, j: Json): EitherT[Task, Rejection, Json] =
     EitherT.rightT(j)
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
@@ -1,7 +1,5 @@
 package ch.epfl.bluebrain.nexus.kg.routes
 
-import java.util.UUID
-
 import akka.http.javadsl.server.Rejections.validationRejection
 import akka.http.scaladsl.model.ContentTypes.`application/octet-stream`
 import akka.http.scaladsl.model.StatusCodes.Created
@@ -10,44 +8,34 @@ import akka.http.scaladsl.model.{ContentType, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Route, Rejection => AkkaRejection}
 import cats.data.{EitherT, OptionT}
-import ch.epfl.bluebrain.nexus.admin.client.types.Project
 import ch.epfl.bluebrain.nexus.commons.es.client.ElasticDecoder
 import ch.epfl.bluebrain.nexus.commons.http.HttpClient
 import ch.epfl.bluebrain.nexus.commons.http.HttpClient.withTaskUnmarshaller
-import ch.epfl.bluebrain.nexus.commons.types.search.QueryResult.UnscoredQueryResult
 import ch.epfl.bluebrain.nexus.commons.types.search.QueryResults
-import ch.epfl.bluebrain.nexus.commons.types.search.QueryResults.UnscoredQueryResults
 import ch.epfl.bluebrain.nexus.iam.client.types._
-import ch.epfl.bluebrain.nexus.kg.DeprecatedId._
 import ch.epfl.bluebrain.nexus.kg._
 import ch.epfl.bluebrain.nexus.kg.async.DistributedCache
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig.HttpConfig
+import ch.epfl.bluebrain.nexus.kg.config.AppConfig.tracing._
 import ch.epfl.bluebrain.nexus.kg.config.Contexts._
-import ch.epfl.bluebrain.nexus.kg.config.Schemas._
 import ch.epfl.bluebrain.nexus.kg.directives.AuthDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.LabeledProject
 import ch.epfl.bluebrain.nexus.kg.directives.PathDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.ProjectDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.QueryDirectives._
-import ch.epfl.bluebrain.nexus.kg.indexing.View.{ElasticView, SparqlView}
-import ch.epfl.bluebrain.nexus.kg.indexing.ViewEncoder._
 import ch.epfl.bluebrain.nexus.kg.marshallers.instances._
-import ch.epfl.bluebrain.nexus.kg.marshallers.{ExceptionHandling, RejectionHandling}
-import ch.epfl.bluebrain.nexus.kg.resolve.ResolverEncoder._
 import ch.epfl.bluebrain.nexus.kg.resources.ElasticDecoders.resourceIdDecoder
-import ch.epfl.bluebrain.nexus.kg.resources.Ref.Latest
-import ch.epfl.bluebrain.nexus.kg.resources.Rejection.{NotFound, UnexpectedState}
+import ch.epfl.bluebrain.nexus.kg.resources.Rejection.NotFound
 import ch.epfl.bluebrain.nexus.kg.resources._
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.Attachment.BinaryDescription
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.AttachmentStore.{AkkaIn, AkkaOut}
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.{Attachment, AttachmentStore}
 import ch.epfl.bluebrain.nexus.kg.routes.ResourceEncoder._
-import ch.epfl.bluebrain.nexus.kg.routes.ResourceRoutes._
 import ch.epfl.bluebrain.nexus.kg.search.QueryResultEncoder._
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import ch.epfl.bluebrain.nexus.rdf.syntax.circe.context._
-import ch.epfl.bluebrain.nexus.service.kamon.directives.TracingDirectives
+import com.github.ghik.silencer.silent
 import io.circe.Json
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -55,324 +43,178 @@ import monix.execution.Scheduler.Implicits.global
 import scala.concurrent.Future
 
 /**
-  * Routes for resources operations
+  * Routes for a specific resource and schema type defined by ''prefix'' abd ''schema'' operations
   *
   * @param resources the resources operations
+  * @param schema    the schema to which the routes match
+  * @param prefix    the prefix to which the routes match
   */
-class ResourceRoutes(resources: Resources[Task])(implicit cache: DistributedCache[Task],
-                                                 indexers: Clients[Task],
-                                                 store: AttachmentStore[Task, AkkaIn, AkkaOut],
-                                                 config: AppConfig,
-                                                 tracing: TracingDirectives) {
+private[routes] class ResourceRoutes(resources: Resources[Task], schema: AbsoluteIri, prefix: String)(
+    implicit private[routes] val wrapped: LabeledProject,
+    private[routes] val acls: Option[FullAccessControlList],
+    token: Option[AuthToken],
+    cache: DistributedCache[Task],
+    indexers: Clients[Task],
+    store: AttachmentStore[Task, AkkaIn, AkkaOut],
+    config: AppConfig) {
 
-  private val (es, sparql) = (indexers.elastic, indexers.sparql)
   import indexers._
-  import tracing._
 
-  def routes: Route =
-    handleRejections(RejectionHandling()) {
-      handleExceptions(ExceptionHandling()) {
-        token { implicit optToken =>
-          pathPrefix(config.http.prefix) {
-            res ~ schemas ~ resolvers ~ views ~ search ~ listings
-          }
+  private val suffixTracing = prefix.capitalize
+
+  def transformCreate(j: Json): Json = j
+
+  def transformUpdate(@silent id: AbsoluteIri, j: Json): EitherT[Task, Rejection, Json] =
+    EitherT.rightT(j)
+
+  implicit def additional: AdditionalValidation[Task] =
+    AdditionalValidation.pass
+
+  def routes: Route = {
+    create ~ list ~ pathPrefix(IdSegment) { id =>
+      // format: off
+      update(id) ~ createWithId(id) ~ tag(id) ~ deprecate(id) ~ addAttachment(id) ~ removeAttachment(id) ~ getResource(id) ~ getResourceAttachment(id)
+      // format: on
+    }
+  }
+
+  def list: Route =
+    (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
+      (deprecated, pagination) =>
+        trace(s"list$suffixTracing") {
+          complete(cache.views(wrapped.ref).flatMap(v => resources.list(v, deprecated, schema, pagination)).runAsync)
+        }
+    }
+
+  def create: Route =
+    (projectNotDeprecated & post & entity(as[Json]) & pathEndOrSingleSlash) { source =>
+      (callerIdentity & hasPermissionInAcl(resourceCreate)) { implicit ident =>
+        trace(s"create$suffixTracing") {
+          val created = resources.create(wrapped.ref, wrapped.base, Ref(schema), transformCreate(source))
+          complete(Created -> created.value.runAsync)
         }
       }
     }
 
-  private def res(implicit token: Option[AuthToken]): Route =
-    // consumes the segment resources/{account}/{project}
-    (pathPrefix("resources") & project) { implicit wrapped =>
-      // create resource with implicit or generated id
-      (post & projectNotDeprecated & pathPrefix(IdSegment) & entity(as[Json]) & pathEndOrSingleSlash) {
-        (schema, source) =>
-          (callerIdentity & hasPermission(resourceCreate)) { implicit ident =>
-            trace("createResource") {
-              complete(
-                Created -> resources.create(wrapped.ref, wrapped.project.base, Ref(schema), source).value.runAsync)
-            }
-          }
-      } ~
-        pathPrefix(IdSegment / IdSegment)((schema, id) => resources(schema, id))
+  def createWithId(id: AbsoluteIri): Route =
+    (put & entity(as[Json]) & projectNotDeprecated & pathEndOrSingleSlash) { source =>
+      (callerIdentity & hasPermissionInAcl(resourceCreate)) { implicit ident =>
+        trace(s"create$suffixTracing") {
+          complete(
+            Created -> resources
+              .createWithId(Id(wrapped.ref, id), Ref(schema), transformCreate(source))
+              .value
+              .runAsync)
+        }
+      }
     }
 
-  private def transformView(source: Json): Json =
-    transformView(source, UUID.randomUUID().toString.toLowerCase)
-
-  private def transformView(source: Json, uuid: String): Json = {
-    val transformed = source deepMerge Json.obj("uuid" -> Json.fromString(uuid)).addContext(viewCtxUri)
-    transformed.hcursor.get[Json]("mapping") match {
-      case Right(m) if m.isObject => transformed deepMerge Json.obj("mapping" -> Json.fromString(m.noSpaces))
-      case _                      => transformed
+  def update(id: AbsoluteIri): Route =
+    (put & entity(as[Json]) & projectNotDeprecated & parameter('rev.as[Long]) & pathEndOrSingleSlash) { (json, rev) =>
+      (callerIdentity & hasPermissionInAcl(resourceWrite)) { implicit ident =>
+        trace(s"update$suffixTracing") {
+          complete(
+            transformUpdate(id, json)
+              .flatMap(transformed => resources.update(Id(wrapped.ref, id), rev, Some(Ref(schema)), transformed))
+              .value
+              .runAsync)
+        }
+      }
     }
-  }
 
-  private def transformViewUpdate(resId: ResId)(source: Json): EitherT[Task, Rejection, Json] =
-    resources
-      .fetch(resId, Some(Latest(viewSchemaUri)))
-      .toRight(NotFound(resId.ref): Rejection)
-      .flatMap(r =>
-        EitherT.fromEither(r.value.hcursor.get[String]("uuid").left.map(_ => UnexpectedState(resId.ref): Rejection)))
-      .map(uuid => transformView(source, uuid))
-
-  private def views(implicit token: Option[AuthToken]): Route =
-    // consumes the segment views/{account}/{project}
-    (pathPrefix("views") & project) { implicit wrapped =>
-      // create view with implicit or generated id
-      (projectNotDeprecated & post & entity(as[Json]) & pathEndOrSingleSlash) { source =>
-        (callerIdentity & hasPermission(resourceCreate)) { implicit ident =>
-          trace("createView") {
-            complete(
-              Created -> resources
-                .create(wrapped.ref, wrapped.base, Ref(viewSchemaUri), transformView(source))
-                .value
-                .runAsync)
+  def tag(id: AbsoluteIri): Route =
+    (pathPrefix("tags") & projectNotDeprecated & put & entity(as[Json]) & parameter('rev.as[Long]) & pathEndOrSingleSlash) {
+      (json, rev) =>
+        (callerIdentity & hasPermissionInAcl(resourceWrite)) { implicit ident =>
+          trace(s"addTag$suffixTracing") {
+            val tagged = resources.tag(Id(wrapped.ref, id), rev, Some(Ref(schema)), json.addContext(tagCtxUri))
+            complete(Created -> tagged.value.runAsync)
           }
         }
-      } ~ listings(viewSchemaUri) ~
-        pathPrefix(IdSegment)(id =>
-          resources(viewSchemaUri, id, transformView, transformViewUpdate(Id(wrapped.ref, id))))
     }
 
-  private def schemas(implicit token: Option[AuthToken]): Route =
-    // consumes the segment schemas/{account}/{project}
-    (pathPrefix("schemas") & project) { implicit wrapped =>
-      // create schema with implicit or generated id
-      (post & projectNotDeprecated & entity(as[Json]) & pathEndOrSingleSlash) { source =>
-        (callerIdentity & hasPermission(resourceCreate)) { implicit ident =>
-          trace("createSchema") {
-            complete(
-              Created -> resources
-                .create(wrapped.ref, wrapped.project.base, Ref(shaclSchemaUri), source)
-                .value
-                .runAsync)
-          }
+  def deprecate(id: AbsoluteIri): Route =
+    (delete & projectNotDeprecated & parameter('rev.as[Long]) & pathEndOrSingleSlash) { rev =>
+      (callerIdentity & hasPermissionInAcl(resourceWrite)) { implicit ident =>
+        trace(s"deprecate$suffixTracing") {
+          complete(resources.deprecate(Id(wrapped.ref, id), rev, Some(Ref(schema))).value.runAsync)
         }
-      } ~ listings(shaclSchemaUri) ~
-        pathPrefix(IdSegment)(id => resources(shaclSchemaUri, id))
+      }
     }
 
-  private def resolvers(implicit token: Option[AuthToken]): Route =
-    // consumes the segment resolvers/{account}/{project}
-    (pathPrefix("resolvers") & project) { implicit wrapped =>
-      // create resolver with implicit or generated id
-      (projectNotDeprecated & post & entity(as[Json]) & pathEndOrSingleSlash) { source =>
-        callerIdentity.apply { implicit ident =>
-          acls.apply { implicit acls =>
-            hasPermissionInAcl(resourceCreate).apply {
-              trace("createResolver") {
+  def addAttachment(id: AbsoluteIri): Route =
+    (pathPrefix("attachments" / Segment) & projectNotDeprecated & put & parameter('rev.as[Long]) & pathEndOrSingleSlash) {
+      (filename, rev) =>
+        (callerIdentity & hasPermissionInAcl(resourceWrite)) { implicit ident =>
+          fileUpload("file") {
+            case (metadata, byteSource) =>
+              val description = BinaryDescription(filename, metadata.contentType.value)
+              trace(s"addAttachment$suffixTracing") {
                 complete(
-                  Created -> resources
-                    .create(wrapped.ref, wrapped.base, Ref(resolverSchemaUri), source.addContext(resolverCtxUri))
+                  resources
+                    .attach(Id(wrapped.ref, id), rev, Some(Ref(schema)), description, byteSource)
                     .value
                     .runAsync)
               }
-            }
-          }
-        }
-      } ~ listings(resolverSchemaUri) ~
-        pathPrefix(IdSegment) { id =>
-          acls.apply { implicit acls =>
-            resources(resolverSchemaUri, id, _.addContext(resolverCtxUri), _.addContext(resolverCtxUri))
           }
         }
     }
 
-  private def search(implicit token: Option[AuthToken]): Route =
-    // consumes the segment views/{account}/{project}
-    (pathPrefix("views") & project) { implicit wrapped =>
-      (pathPrefix(IdSegment / "sparql") & post & entity(as[String]) & pathEndOrSingleSlash) { (id, query) =>
-        (callerIdentity & hasPermission(resourceRead)) { implicit ident =>
-          val result: Task[Either[Rejection, Json]] = cache.views(wrapped.ref).flatMap { views =>
-            views.find(_.id == id) match {
-              case Some(v: SparqlView) => sparql.copy(namespace = v.name).queryRaw(urlEncode(query)).map(Right.apply)
-              case _                   => Task.pure(Left(NotFound(Ref(id))))
-            }
+  def removeAttachment(id: AbsoluteIri): Route =
+    (pathPrefix("attachments" / Segment) & projectNotDeprecated & delete & parameter('rev.as[Long]) & pathEndOrSingleSlash) {
+      (filename, rev) =>
+        (callerIdentity & hasPermissionInAcl(resourceWrite)) { implicit ident =>
+          trace(s"removeAttachment$suffixTracing") {
+            complete(resources.unattach(Id(wrapped.ref, id), rev, Some(Ref(schema)), filename).value.runAsync)
           }
-          trace("searchSparql")(complete(result.runAsync))
-        }
-      } ~
-        (pathPrefix(IdSegment / "_search") & post & entity(as[Json]) & paginated & extract(_.request.uri.query()) & pathEndOrSingleSlash) {
-          (id, query, pagination, params) =>
-            (callerIdentity & hasPermission(resourceRead)) { implicit ident =>
-              val result: Task[Either[Rejection, List[Json]]] = cache.views(wrapped.ref).flatMap { views =>
-                views.find(_.id == id) match {
-                  case Some(v: ElasticView) =>
-                    val index = s"${config.elastic.indexPrefix}_${v.name}"
-                    es.search[Json](query, Set(index), params)(pagination).map(qr => Right(qr.results.map(_.source)))
-                  case _ =>
-                    Task.pure(Left(NotFound(Ref(id))))
-                }
-              }
-              trace("searchElastic")(complete(result.runAsync))
-            }
         }
     }
 
-  private def listings(schema: AbsoluteIri)(implicit wrapped: LabeledProject, token: Option[AuthToken]): Route = {
-    (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermission(resourceRead) & pathEndOrSingleSlash) {
-      (deprecated, pagination) =>
-        schema match {
-          case `resolverSchemaUri` =>
-            trace("listResolvers") {
-              val qr = filterDeprecated(cache.resolvers(wrapped.ref), deprecated).map { r =>
-                toQueryResults(r.sortBy(_.priority))
-              }
-              complete(qr.runAsync)
-            }
-
-          case `viewSchemaUri` =>
-            trace("listViews") {
-              complete(filterDeprecated(cache.views(wrapped.ref), deprecated).map(toQueryResults).runAsync)
-            }
-          case _ =>
-            trace("listResources") {
-              complete(
-                cache.views(wrapped.ref).flatMap(v => resources.list(v, deprecated, schema, pagination)).runAsync)
-            }
+  def getResource(id: AbsoluteIri): Route =
+    (get & parameter('rev.as[Long].?) & parameter('tag.?) & pathEndOrSingleSlash) { (revOpt, tagOpt) =>
+      (callerIdentity & hasPermissionInAcl(resourceRead)) { implicit ident =>
+        trace(s"get$suffixTracing") {
+          (revOpt, tagOpt) match {
+            case (None, None) =>
+              complete(resources.fetch(Id(wrapped.ref, id), Some(Ref(schema))).materializeRun(Ref(id)))
+            case (Some(_), Some(_)) =>
+              reject(simultaneousParamsRejection)
+            case (Some(rev), _) =>
+              complete(resources.fetch(Id(wrapped.ref, id), rev, Some(Ref(schema))).materializeRun(Ref(id)))
+            case (_, Some(tag)) =>
+              complete(resources.fetch(Id(wrapped.ref, id), tag, Some(Ref(schema))).materializeRun(Ref(id)))
+          }
         }
-    }
-  }
-
-  private def listings(implicit token: Option[AuthToken]): Route =
-    (pathPrefix("resources") & project) { implicit wrapped =>
-      (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermission(resourceRead) & pathEndOrSingleSlash) {
-        (deprecated, pagination) =>
-          val results = cache.views(wrapped.ref).flatMap(v => resources.list(v, deprecated, pagination))
-          trace("listResources") {
-            complete(results.runAsync)
-          }
-      } ~ pathPrefix(IdSegment)(listings)
-    }
-
-  private def resources(schema: AbsoluteIri,
-                        id: AbsoluteIri,
-                        transformCreate: Json => Json = j => j,
-                        transformUpdate: Json => EitherT[Task, Rejection, Json] = j => EitherT.rightT(j))(
-      implicit wrapped: LabeledProject,
-      token: Option[AuthToken],
-      additional: AdditionalValidation[Task] = AdditionalValidation.pass): Route =
-    (put & entity(as[Json]) & projectNotDeprecated & pathEndOrSingleSlash) { source =>
-      parameter('rev.as[Long].?) {
-        case Some(rev) =>
-          // updates a resource
-          (callerIdentity & hasPermission(resourceWrite)) { implicit ident =>
-            trace("updateResource") {
-              complete(
-                transformUpdate(source)
-                  .flatMap(transformed => resources.update(Id(wrapped.ref, id), rev, Some(Ref(schema)), transformed))
-                  .value
-                  .runAsync)
-            }
-          }
-        case None =>
-          // create resource with explicit id
-          (callerIdentity & hasPermission(resourceCreate)) { implicit ident =>
-            trace("createResource") {
-              complete(
-                Created -> resources
-                  .createWithId(Id(wrapped.ref, id), Ref(schema), transformCreate(source))
-                  .value
-                  .runAsync)
-            }
-          }
       }
-    } ~
-      // add tag to resource
-      (pathPrefix("tags") & projectNotDeprecated) {
-        (put & parameter('rev.as[Long]) & entity(as[Json]) & pathEndOrSingleSlash) { (rev, json) =>
-          (callerIdentity & hasPermission(resourceWrite)) { implicit ident =>
-            trace("addTagResource") {
-              complete(
-                Created -> resources
-                  .tag(Id(wrapped.ref, id), rev, Some(Ref(schema)), json.addContext(tagCtxUri))
-                  .value
-                  .runAsync)
-            }
-          }
-        }
-      } ~
-      // deprecate a resource
-      (delete & projectNotDeprecated & parameter('rev.as[Long]) & pathEndOrSingleSlash) { rev =>
-        (callerIdentity & hasPermission(resourceWrite)) { implicit ident =>
-          trace("deprecateResource") {
-            complete(resources.deprecate(Id(wrapped.ref, id), rev, Some(Ref(schema))).value.runAsync)
-          }
-        }
-      } ~
-      (pathPrefix("attachments" / Segment) & projectNotDeprecated) { filename =>
-        // remove a resource attachment
-        (delete & parameter('rev.as[Long]) & pathEndOrSingleSlash) { rev =>
-          (callerIdentity & hasPermission(resourceWrite)) { implicit ident =>
-            trace("removeAttachmentResource") {
-              complete(resources.unattach(Id(wrapped.ref, id), rev, Some(Ref(schema)), filename).value.runAsync)
-            }
-          }
-        } ~
-          // add an attachment to resources
-          (put & parameter('rev.as[Long]) & pathEndOrSingleSlash) { rev =>
-            (callerIdentity & hasPermission(resourceWrite)) { implicit ident =>
-              fileUpload("file") {
-                case (metadata, byteSource) =>
-                  val description = BinaryDescription(filename, metadata.contentType.value)
-                  trace("addAttachmentResource") {
-                    complete(
-                      resources
-                        .attach(Id(wrapped.ref, id), rev, Some(Ref(schema)), description, byteSource)
-                        .value
-                        .runAsync)
-                  }
-              }
-            }
-          }
-      } ~
-      (parameter('rev.as[Long].?) & parameter('tag.?)) { (revOpt, tagOpt) =>
-        // get a resource
-        (get & pathEndOrSingleSlash) {
-          (callerIdentity & hasPermission(resourceRead)) { implicit ident =>
-            trace("getResource") {
-              (revOpt, tagOpt) match {
-                case (None, None) =>
-                  complete(resources.fetch(Id(wrapped.ref, id), Some(Ref(schema))).materializeRun(Ref(id)))
-                case (Some(_), Some(_)) =>
-                  reject(simultaneousParamsRejection)
-                case (Some(rev), _) =>
-                  complete(resources.fetch(Id(wrapped.ref, id), rev, Some(Ref(schema))).materializeRun(Ref(id)))
-                case (_, Some(tag)) =>
-                  complete(resources.fetch(Id(wrapped.ref, id), tag, Some(Ref(schema))).materializeRun(Ref(id)))
-              }
-            }
-          }
-        } ~
-          (pathPrefix("attachments" / Segment) & pathEndOrSingleSlash) { filename =>
-            // get a resource attachment
-            (get & callerIdentity & hasPermission(resourceRead)) { implicit ident =>
-              val result = (revOpt, tagOpt) match {
-                case (None, None) =>
-                  resources.fetchAttachment(Id(wrapped.ref, id), Some(Ref(schema)), filename).toEitherRun
-                case (Some(_), Some(_)) => Future.successful(Left(simultaneousParamsRejection): RejectionOrAttachment)
-                case (Some(rev), _) =>
-                  resources.fetchAttachment(Id(wrapped.ref, id), rev, Some(Ref(schema)), filename).toEitherRun
-                case (_, Some(tag)) =>
-                  resources.fetchAttachment(Id(wrapped.ref, id), tag, Some(Ref(schema)), filename).toEitherRun
-              }
-              trace("getResourceAttachment") {
-                onSuccess(result) {
-                  case Left(rej) => reject(rej)
-                  case Right(Some((info, source))) =>
-                    respondWithHeaders(filenameHeader(info)) {
-                      complete(HttpEntity(contentType(info), info.contentSize.value, source))
-                    }
-                  case _ =>
-                    complete(StatusCodes.NotFound)
-                }
-              }
-            }
-          }
-      }
+    }
 
-  private def filterDeprecated[A: DeprecatedId](set: Task[Set[A]], deprecated: Option[Boolean]): Task[List[A]] =
-    set.map(s => deprecated.map(d => s.filter(_.deprecated == d)).getOrElse(s).toList)
+  def getResourceAttachment(id: AbsoluteIri): Route =
+    (parameter('rev.as[Long].?) & parameter('tag.?)) { (revOpt, tagOpt) =>
+      (pathPrefix("attachments" / Segment) & get & pathEndOrSingleSlash) { filename =>
+        (callerIdentity & hasPermissionInAcl(resourceRead)) { implicit ident =>
+          val result = (revOpt, tagOpt) match {
+            case (None, None) =>
+              resources.fetchAttachment(Id(wrapped.ref, id), Some(Ref(schema)), filename).toEitherRun
+            case (Some(_), Some(_)) => Future.successful(Left(simultaneousParamsRejection): RejectionOrAttachment)
+            case (Some(rev), _) =>
+              resources.fetchAttachment(Id(wrapped.ref, id), rev, Some(Ref(schema)), filename).toEitherRun
+            case (_, Some(tag)) =>
+              resources.fetchAttachment(Id(wrapped.ref, id), tag, Some(Ref(schema)), filename).toEitherRun
+          }
+          trace(s"getAttachment$suffixTracing") {
+            onSuccess(result) {
+              case Left(rej) => reject(rej)
+              case Right(Some((info, source))) =>
+                respondWithHeaders(filenameHeader(info)) {
+                  complete(HttpEntity(contentType(info), info.contentSize.value, source))
+                }
+              case _ =>
+                complete(StatusCodes.NotFound)
+            }
+          }
+        }
+      }
+    }
 
   private implicit def qrsClient(implicit wrapped: LabeledProject,
                                  http: HttpConfig): HttpClient[Task, QueryResults[AbsoluteIri]] = {
@@ -383,26 +225,16 @@ class ResourceRoutes(resources: Resources[Task])(implicit cache: DistributedCach
   private val simultaneousParamsRejection: AkkaRejection =
     validationRejection("'rev' and 'tag' query parameters cannot be present simultaneously.")
 
-  private implicit def toEither[A](a: A): EitherT[Task, Rejection, A] =
-    EitherT.rightT[Task, Rejection](a)
-
   private implicit class OptionTaskSyntax(resource: OptionT[Task, Resource]) {
     def materializeRun(ref: => Ref): Future[Either[Rejection, ResourceV]] =
-      resource.toRight(NotFound(ref): Rejection).flatMap(resources.materializeWithMeta(_)).value.runAsync
+      resource.toRight(NotFound(ref): Rejection).flatMap(resources.materializeWithMeta).value.runAsync
   }
-
-  private def toQueryResults[A](resolvers: List[A]): QueryResults[A] =
-    UnscoredQueryResults(resolvers.size.toLong, resolvers.map(UnscoredQueryResult(_)))
 
   private type RejectionOrAttachment = Either[AkkaRejection, Option[(Attachment.BinaryAttributes, AkkaOut)]]
   private implicit class OptionTaskAttachmentSyntax(resource: OptionT[Task, (Attachment.BinaryAttributes, AkkaOut)]) {
     def toEitherRun: Future[RejectionOrAttachment] =
       resource.value.map[RejectionOrAttachment](Right.apply).runAsync
   }
-
-  private implicit def resolverAclValidation(implicit acls: Option[FullAccessControlList],
-                                             wrapped: LabeledProject): AdditionalValidation[Task] =
-    AdditionalValidation.resolver(acls, wrapped.accountRef, cache.projectRef)
 
   private def filenameHeader(info: Attachment.BinaryAttributes) = {
     val filename = urlEncodeOrElse(info.filename)("attachment")
@@ -412,26 +244,30 @@ class ResourceRoutes(resources: Resources[Task])(implicit cache: DistributedCach
   private def contentType(info: Attachment.BinaryAttributes) =
     ContentType.parse(info.mediaType).getOrElse(`application/octet-stream`)
 
-  private implicit def toProject(implicit value: LabeledProject): Project           = value.project
-  private implicit def toProjectLabel(implicit value: LabeledProject): ProjectLabel = value.label
+  private[routes] val resourceRead =
+    Permissions(Permission(s"$prefix/read"), Permission(s"$prefix/manage"))
+  private[routes] val resourceWrite =
+    Permissions(Permission(s"$prefix/write"), Permission(s"$prefix/manage"))
+  private[routes] val resourceCreate =
+    Permissions(Permission(s"$prefix/create"), Permission(s"$prefix/manage"))
 
 }
 
 object ResourceRoutes {
 
-  /**
-    * @param resources the resources operations
-    * @return a new insrtance of a [[ResourceRoutes]]
-    */
-  final def apply(resources: Resources[Task])(implicit cache: DistributedCache[Task],
-                                              indexers: Clients[Task],
-                                              store: AttachmentStore[Task, AkkaIn, AkkaOut],
-                                              config: AppConfig): ResourceRoutes = {
-    implicit val tracing = new TracingDirectives()
-    new ResourceRoutes(resources)
-  }
+  private[routes] def apply(resources: Resources[Task], schema: AbsoluteIri, prefixSegment: String)(
+      implicit cache: DistributedCache[Task],
+      token: Option[AuthToken],
+      indexers: Clients[Task],
+      store: AttachmentStore[Task, AkkaIn, AkkaOut],
+      config: AppConfig): Route = {
 
-  private[routes] val resourceRead   = Permissions(Permission("resources/read"), Permission("resources/manage"))
-  private[routes] val resourceWrite  = Permissions(Permission("resources/write"), Permission("resources/manage"))
-  private[routes] val resourceCreate = Permissions(Permission("resources/create"), Permission("resources/manage"))
+    import indexers._
+
+    // consumes the segment {prefixSegment}/{account}/{project}
+    (pathPrefix(prefixSegment) & project) { implicit wrapped =>
+      //Fetches the ACLs for the current project
+      acls.apply(implicit acls => new ResourceRoutes(resources, schema, prefixSegment).routes)
+    }
+  }
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
@@ -1,0 +1,180 @@
+package ch.epfl.bluebrain.nexus.kg.routes
+
+import java.util.UUID
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import cats.data.EitherT
+import ch.epfl.bluebrain.nexus.commons.types.search.QueryResult.UnscoredQueryResult
+import ch.epfl.bluebrain.nexus.commons.types.search.QueryResults
+import ch.epfl.bluebrain.nexus.commons.types.search.QueryResults.UnscoredQueryResults
+import ch.epfl.bluebrain.nexus.iam.client.types._
+import ch.epfl.bluebrain.nexus.kg.DeprecatedId._
+import ch.epfl.bluebrain.nexus.kg._
+import ch.epfl.bluebrain.nexus.kg.async.DistributedCache
+import ch.epfl.bluebrain.nexus.kg.config.AppConfig
+import ch.epfl.bluebrain.nexus.kg.config.AppConfig.tracing._
+import ch.epfl.bluebrain.nexus.kg.config.Contexts._
+import ch.epfl.bluebrain.nexus.kg.config.Schemas._
+import ch.epfl.bluebrain.nexus.kg.directives.AuthDirectives._
+import ch.epfl.bluebrain.nexus.kg.directives.LabeledProject
+import ch.epfl.bluebrain.nexus.kg.directives.PathDirectives._
+import ch.epfl.bluebrain.nexus.kg.directives.ProjectDirectives._
+import ch.epfl.bluebrain.nexus.kg.directives.QueryDirectives._
+import ch.epfl.bluebrain.nexus.kg.indexing.View.{ElasticView, SparqlView}
+import ch.epfl.bluebrain.nexus.kg.indexing.ViewEncoder._
+import ch.epfl.bluebrain.nexus.kg.marshallers.instances._
+import ch.epfl.bluebrain.nexus.kg.marshallers.{ExceptionHandling, RejectionHandling}
+import ch.epfl.bluebrain.nexus.kg.resolve.ResolverEncoder._
+import ch.epfl.bluebrain.nexus.kg.resources.Ref.Latest
+import ch.epfl.bluebrain.nexus.kg.resources.Rejection.{NotFound, UnexpectedState}
+import ch.epfl.bluebrain.nexus.kg.resources._
+import ch.epfl.bluebrain.nexus.kg.resources.attachment.AttachmentStore
+import ch.epfl.bluebrain.nexus.kg.resources.attachment.AttachmentStore.{AkkaIn, AkkaOut}
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import ch.epfl.bluebrain.nexus.rdf.syntax.circe.context._
+import com.github.ghik.silencer.silent
+import io.circe.Json
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+
+/**
+  * Routes for resources operations
+  *
+  * @param resources the resources operations
+  */
+class ResourcesRoutes(resources: Resources[Task])(implicit cache: DistributedCache[Task],
+                                                  indexers: Clients[Task],
+                                                  store: AttachmentStore[Task, AkkaIn, AkkaOut],
+                                                  config: AppConfig) {
+
+  private val (es, sparql) = (indexers.elastic, indexers.sparql)
+  import indexers._
+
+  def routes: Route =
+    handleRejections(RejectionHandling()) {
+      handleExceptions(ExceptionHandling()) {
+        token { implicit optToken =>
+          pathPrefix(config.http.prefix) {
+            resource ~ schema ~ resolver ~ view
+          }
+        }
+      }
+    }
+
+  private def resolver(implicit token: Option[AuthToken]): Route =
+    (pathPrefix("resolvers") & project) { implicit wrapped =>
+      acls.apply { implicit acls =>
+        new ResourceRoutes(resources, resolverSchemaUri, "resolvers") {
+          override def transformCreate(j: Json) =
+            j.addContext(resolverCtxUri)
+
+          override def transformUpdate(@silent id: AbsoluteIri, j: Json) =
+            EitherT.rightT(transformCreate(j))
+
+          override implicit def additional =
+            AdditionalValidation.resolver(acls, wrapped.accountRef, cache.projectRef)
+
+          override def list: Route =
+            (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
+              (deprecated, pagination) =>
+                trace("listResolvers") {
+                  val qr = filterDeprecated(cache.resolvers(wrapped.ref), deprecated).map { r =>
+                    toQueryResults(r.sortBy(_.priority))
+                  }
+                  complete(qr.runAsync)
+                }
+            }
+        }.routes
+      }
+    }
+
+  private def view(implicit token: Option[AuthToken]): Route = {
+    val resourceRead = Permissions(Permission("views/read"), Permission("views/manage"))
+
+    def search(implicit wrapped: LabeledProject, acls: Option[FullAccessControlList]) =
+      (pathPrefix(IdSegment / "sparql") & post & entity(as[String]) & pathEndOrSingleSlash) { (id, query) =>
+        (callerIdentity & hasPermissionInAcl(resourceRead)) { implicit ident =>
+          val result: Task[Either[Rejection, Json]] = cache.views(wrapped.ref).flatMap { views =>
+            views.find(_.id == id) match {
+              case Some(v: SparqlView) => sparql.copy(namespace = v.name).queryRaw(urlEncode(query)).map(Right.apply)
+              case _                   => Task.pure(Left(NotFound(Ref(id))))
+            }
+          }
+          trace("searchSparql")(complete(result.runAsync))
+        }
+      } ~
+        (pathPrefix(IdSegment / "_search") & post & entity(as[Json]) & paginated & extract(_.request.uri.query()) & pathEndOrSingleSlash) {
+          (id, query, pagination, params) =>
+            (callerIdentity & hasPermissionInAcl(resourceRead)) { implicit ident =>
+              val result: Task[Either[Rejection, List[Json]]] = cache.views(wrapped.ref).flatMap { views =>
+                views.find(_.id == id) match {
+                  case Some(v: ElasticView) =>
+                    val index = s"${config.elastic.indexPrefix}_${v.name}"
+                    es.search[Json](query, Set(index), params)(pagination).map(qr => Right(qr.results.map(_.source)))
+                  case _ =>
+                    Task.pure(Left(NotFound(Ref(id))))
+                }
+              }
+              trace("searchElastic")(complete(result.runAsync))
+            }
+        }
+
+    (pathPrefix("views") & project) { implicit wrapped =>
+      acls.apply { implicit acls =>
+        new ResourceRoutes(resources, viewSchemaUri, "views") {
+
+          private def transformView(source: Json, uuid: String): Json = {
+            val transformed = source deepMerge Json.obj("uuid" -> Json.fromString(uuid)).addContext(viewCtxUri)
+            transformed.hcursor.get[Json]("mapping") match {
+              case Right(m) if m.isObject => transformed deepMerge Json.obj("mapping" -> Json.fromString(m.noSpaces))
+              case _                      => transformed
+            }
+          }
+
+          override def list: Route =
+            (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
+              (deprecated, pagination) =>
+                trace("listViews") {
+                  complete(filterDeprecated(cache.views(wrapped.ref), deprecated).map(toQueryResults).runAsync)
+                }
+            }
+
+          override def transformCreate(j: Json): Json =
+            transformView(j, UUID.randomUUID().toString.toLowerCase)
+
+          override def transformUpdate(id: AbsoluteIri, j: Json): EitherT[Task, Rejection, Json] = {
+            val resId = Id(wrapped.ref, id)
+            resources
+              .fetch(resId, Some(Latest(viewSchemaUri)))
+              .toRight(NotFound(resId.ref): Rejection)
+              .flatMap(r =>
+                EitherT.fromEither(
+                  r.value.hcursor.get[String]("uuid").left.map(_ => UnexpectedState(resId.ref): Rejection)))
+              .map(uuid => transformView(j, uuid))
+          }
+        }.routes ~ search
+      }
+    } ~ (pathPrefix("resources") & project & pathPrefix("view")) { implicit wrapped =>
+      acls.apply(implicit acls => search)
+    }
+  }
+
+  private def schema(implicit token: Option[AuthToken]): Route =
+    ResourceRoutes(resources, shaclSchemaUri, "schemas")
+
+  private def resource(implicit token: Option[AuthToken]): Route =
+    (pathPrefix("resources") & project) { implicit wrapped =>
+      acls.apply { implicit acls =>
+        pathPrefix(IdSegment) { schema =>
+          new ResourceRoutes(resources, schema, "resources").routes
+        }
+      }
+    }
+
+  private def filterDeprecated[A: DeprecatedId](set: Task[Set[A]], deprecated: Option[Boolean]): Task[List[A]] =
+    set.map(s => deprecated.map(d => s.filter(_.deprecated == d)).getOrElse(s).toList)
+
+  private def toQueryResults[A](resolvers: List[A]): QueryResults[A] =
+    UnscoredQueryResults(resolvers.size.toLong, resolvers.map(UnscoredQueryResult(_)))
+}

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
@@ -56,7 +56,7 @@ class ResourcesRoutes(resources: Resources[Task])(implicit cache: DistributedCac
       handleExceptions(ExceptionHandling()) {
         token { implicit optToken =>
           pathPrefix(config.http.prefix) {
-            resource ~ schema ~ resolver ~ view
+            resolver ~ view ~ schema ~ resource
           }
         }
       }
@@ -75,8 +75,8 @@ class ResourcesRoutes(resources: Resources[Task])(implicit cache: DistributedCac
           AdditionalValidation.resolver(acls, wrapped.accountRef, cache.projectRef)
 
         override def list: Route =
-          (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
-            (deprecated, pagination) =>
+          (get & parameter('deprecated.as[Boolean].?) & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
+            deprecated =>
               trace("listResolvers") {
                 val qr = filterDeprecated(cache.resolvers(wrapped.ref), deprecated).map { r =>
                   toQueryResults(r.sortBy(_.priority))
@@ -138,8 +138,8 @@ class ResourcesRoutes(resources: Resources[Task])(implicit cache: DistributedCac
         }
 
         override def list: Route =
-          (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
-            (deprecated, pagination) =>
+          (get & parameter('deprecated.as[Boolean].?) & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
+            deprecated =>
               trace("listViews") {
                 complete(filterDeprecated(cache.views(wrapped.ref), deprecated).map(toQueryResults).runAsync)
               }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/package.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/package.scala
@@ -1,0 +1,12 @@
+package ch.epfl.bluebrain.nexus.kg
+
+import ch.epfl.bluebrain.nexus.admin.client.types.Project
+import ch.epfl.bluebrain.nexus.kg.directives.LabeledProject
+import ch.epfl.bluebrain.nexus.kg.resources.ProjectLabel
+
+package object routes {
+
+  private[routes] implicit def toProject(implicit value: LabeledProject): Project           = value.project
+  private[routes] implicit def toProjectLabel(implicit value: LabeledProject): ProjectLabel = value.label
+
+}


### PR DESCRIPTION
Also took the chance to add granular permissions:

Fixes #430 

Also adds the possibility to access the views POST endpoint through
- `/views/{org}/{proj}/{id}/[_search|sparql]`
- `/resources/{org}/{proj}/view/{id}/[_search|sparql]`