### PR TITLE
Added check on mapping object in ElasticView

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ scalafmt: {
 // Dependency versions
 val adminVersion                = "0.2.8"
 val iamVersion                  = "0.10.23"
-val commonsVersion              = "0.10.20"
+val commonsVersion              = "0.10.21"
 val rdfVersion                  = "0.2.18"
 val serviceVersion              = "0.10.14"
 val sourcingVersion             = "0.10.7"

--- a/src/main/resources/elastic/mapping.json
+++ b/src/main/resources/elastic/mapping.json
@@ -1,19 +1,35 @@
 {
-  "mappings": {
-    "{{docType}}": {
-      "properties": {
-        "@type": {"type": "keyword"},
-        "@id": {"type": "keyword"},
-        "_rev": {"type": "long"},
-        "_deprecated": {"type": "boolean"},
-        "_createdAt": {"type": "date"},
-        "_updatedAt": {"type": "date"},
-        "_createdBy": {"type": "keyword"},
-        "_updatedBy": {"type": "keyword"},
-        "_constrainedBy": {"type": "keyword"},
-        "_original_source": {"type": "text"}
-      },
-      "dynamic": false
+  "properties": {
+    "@type": {
+      "type": "keyword"
+    },
+    "@id": {
+      "type": "keyword"
+    },
+    "_rev": {
+      "type": "long"
+    },
+    "_deprecated": {
+      "type": "boolean"
+    },
+    "_createdAt": {
+      "type": "date"
+    },
+    "_updatedAt": {
+      "type": "date"
+    },
+    "_createdBy": {
+      "type": "keyword"
+    },
+    "_updatedBy": {
+      "type": "keyword"
+    },
+    "_constrainedBy": {
+      "type": "keyword"
+    },
+    "_original_source": {
+      "type": "text"
     }
-  }
+  },
+  "dynamic": false
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/View.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/View.scala
@@ -142,7 +142,7 @@ object View {
     def index(implicit config: ElasticConfig): String = s"${config.indexPrefix}_$name"
 
     /**
-      * Attempts to Vi the index for the [[ElasticView]].
+      * Attempts to create the index for the [[ElasticView]].
       *
       * @tparam F the effect type
       * @return ''Unit'' when the index was successfully created, a ''Rejection'' signaling the type of error

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/View.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/View.scala
@@ -12,6 +12,7 @@ import ch.epfl.bluebrain.nexus.kg.resources._
 import ch.epfl.bluebrain.nexus.kg.{DeprecatedId, RevisionedId}
 import ch.epfl.bluebrain.nexus.rdf.Graph._
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import ch.epfl.bluebrain.nexus.rdf.encoder.NodeEncoder
 import ch.epfl.bluebrain.nexus.rdf.syntax.node._
 import ch.epfl.bluebrain.nexus.rdf.syntax.node.encoder._
 import io.circe.Json
@@ -58,22 +59,34 @@ sealed trait View extends Product with Serializable {
 }
 
 object View {
+  private val allowedMappingKeys: Set[String] = Set("dynamic_templates", "properties", "dynamic")
+
+  private implicit class NodeEncoderResultSyntax[A](private val enc: NodeEncoder.EncoderResult[A]) extends AnyVal {
+    def toInvalidPayloadEither(ref: Ref): Either[Rejection, A] =
+      enc.left.map(err =>
+        InvalidPayload(ref, s"The provided payload could not be mapped to a view due to '${err.message}'"))
+  }
 
   /**
     * Attempts to transform the resource into a [[ch.epfl.bluebrain.nexus.kg.indexing.View]].
     *
     * @param res a materialized resource
-    * @return Some(view) if the resource is compatible with a View, None otherwise
+    * @return Right(view) if the resource is compatible with a View, Left(rejection) otherwise
     */
-  final def apply(res: ResourceV): Option[View] = {
+  final def apply(res: ResourceV): Either[Rejection, View] = {
     val c          = res.value.graph.cursor(res.id.value)
     val uuidEither = c.downField(nxv.uuid).focus.as[UUID]
 
-    def elastic(): Option[View] = {
+    def validMapping(mapping: Json): Boolean =
+      mapping.asObject.map(_.keys.toSet.subsetOf(allowedMappingKeys)).getOrElse(false)
+
+    def elastic(): Either[Rejection, View] =
       // format: off
-      val result = for {
-        uuid          <- uuidEither
-        mapping       <- c.downField(nxv.mapping).focus.as[String].flatMap(parse)
+      for {
+        uuid          <- uuidEither.toInvalidPayloadEither(res.id.ref)
+        mappingStr    <- c.downField(nxv.mapping).focus.as[String].toInvalidPayloadEither(res.id.ref)
+        mapping       <- parse(mappingStr).left.map[Rejection](_ => InvalidPayload(res.id.ref, "mappings cannot be parsed into Json"))
+        _             <- if (validMapping(mapping)) Right(()) else Left(InvalidPayload(res.id.ref, s"mappings should only contain some of the following keys: '${allowedMappingKeys.mkString(", ")}'"))
         schemas       = c.downField(nxv.resourceSchemas).values.asListOf[AbsoluteIri].map(_.toSet).getOrElse(Set.empty)
         tag           = c.downField(nxv.resourceTag).focus.as[String].toOption
         includeMeta   = c.downField(nxv.includeMetadata).focus.as[Boolean].getOrElse(false)
@@ -81,17 +94,15 @@ object View {
       } yield
         ElasticView(mapping, schemas, tag, includeMeta, sourceAsText, res.id.parent, res.id.value, uuid.toString.toLowerCase, res.rev, res.deprecated)
       // format: on
-      result.toOption
-    }
 
-    def sparql(): Option[View] =
+    def sparql(): Either[Rejection, View] =
       uuidEither
+        .toInvalidPayloadEither(res.id.ref)
         .map(uuid => SparqlView(res.id.parent, res.id.value, uuid.toString.toLowerCase, res.rev, res.deprecated))
-        .toOption
 
     if (Set(nxv.View.value, nxv.Alpha.value, nxv.ElasticView.value).subsetOf(res.types)) elastic()
     else if (Set(nxv.View.value, nxv.SparqlView.value).subsetOf(res.types)) sparql()
-    else None
+    else Left(InvalidPayload(res.id.ref, "The provided @type do not match any of the view types"))
   }
 
   /**
@@ -131,7 +142,7 @@ object View {
     def index(implicit config: ElasticConfig): String = s"${config.indexPrefix}_$name"
 
     /**
-      * Attempts to create the index for the [[ElasticView]].
+      * Attempts to Vi the index for the [[ElasticView]].
       *
       * @tparam F the effect type
       * @return ''Unit'' when the index was successfully created, a ''Rejection'' signaling the type of error
@@ -142,7 +153,7 @@ object View {
                           config: ElasticConfig,
                           F: MonadError[F, Throwable]): F[Either[Rejection, Unit]] =
       elastic
-        .createIndex(index, mapping)
+        .createIndex(index, Json.obj("mappings" -> Json.obj(config.docType -> mapping)))
         .map[Either[Rejection, Unit]] {
           case true  => Right(())
           case false => Left(Unexpected("View mapping validation could not be performed"))

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/ViewIndexer.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/ViewIndexer.scala
@@ -37,7 +37,7 @@ private class ViewIndexer[F[_]](resources: Resources[F], cache: DistributedCache
     val result: EitherT[F, Rejection, Boolean] = for {
       resource     <- resources.fetch(event.id, None).toRight[Rejection](NotFound(event.id.ref))
       materialized <- resources.materialize(resource)
-      view         <- EitherT.fromOption(View(materialized), NotFound(event.id.ref))
+      view         <- EitherT.fromEither(View(materialized))
       applied      <- EitherT.liftF(cache.applyView(projectRef, view))
     } yield applied
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/marshallers/package.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/marshallers/package.scala
@@ -2,7 +2,6 @@ package ch.epfl.bluebrain.nexus.kg
 
 import cats.Show
 import cats.syntax.show._
-import ch.epfl.bluebrain.nexus.commons.shacl.topquadrant.ValidationReport
 import ch.epfl.bluebrain.nexus.commons.types.HttpRejection
 import ch.epfl.bluebrain.nexus.kg.config.Contexts._
 import ch.epfl.bluebrain.nexus.kg.resources.Rejection
@@ -22,9 +21,6 @@ package object marshallers {
     * The discriminator is enough to give us a Json representation (the name of the class)
     */
   private[marshallers] implicit val rejectionConfig: Configuration = Configuration.default.withDiscriminator("code")
-
-  private[marshallers] implicit val validationReportEnc: Encoder[ValidationReport] =
-    Encoder.instance(_.json)
 
   private[marshallers] implicit val rejectionEncoder: Encoder[Rejection] = {
     val enc = deriveEncoder[Rejection]

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/AdditionalValidation.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/AdditionalValidation.scala
@@ -50,11 +50,9 @@ object AdditionalValidation {
                        config: ElasticConfig): AdditionalValidation[F] =
     (id: ResId, schema: Ref, types: Set[AbsoluteIri], value: Value) => {
       val resource = ResourceF.simpleV(id, value, types = types, schema = schema)
-      View(resource) match {
-        case Some(es: ElasticView) => EitherT(es.createIndex[F]).map(_ => value)
-        case Some(_)               => EitherT.rightT(value)
-        case _ =>
-          EitherT.leftT(InvalidPayload(id.ref, "The provided payload could not be mapped to a view"): Rejection)
+      EitherT.fromEither(View(resource)).flatMap {
+        case es: ElasticView => EitherT(es.createIndex[F]).map(_ => value)
+        case _               => EitherT.rightT(value)
       }
     }
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/ResourceF.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/ResourceF.scala
@@ -14,6 +14,7 @@ import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import ch.epfl.bluebrain.nexus.rdf.Node.{IriNode, IriOrBNode}
 import ch.epfl.bluebrain.nexus.rdf.Vocabulary._
 import ch.epfl.bluebrain.nexus.rdf.syntax.circe._
+import ch.epfl.bluebrain.nexus.rdf.syntax.circe.context._
 import ch.epfl.bluebrain.nexus.rdf.syntax.nexus._
 import ch.epfl.bluebrain.nexus.rdf.syntax.node._
 import ch.epfl.bluebrain.nexus.rdf.{Graph, Node}
@@ -117,10 +118,12 @@ object ResourceF {
     * @param graph  a graph representation of a resource
     */
   final case class Value(source: Json, ctx: Json, graph: Graph) {
-    def primaryNode: Option[IriOrBNode] =
-      source.id.map(IriNode(_)) orElse graph.primaryNode orElse Option(graph.triples.isEmpty).collect {
+    def primaryNode: Option[IriOrBNode] = {
+      val resolvedSource = source appendContextOf Json.obj("@context" -> ctx)
+      resolvedSource.id.map(IriNode(_)) orElse graph.primaryNode orElse Option(graph.triples.isEmpty).collect {
         case true => Node.blank
       }
+    }
   }
 
   /**

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Resources.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Resources.scala
@@ -6,7 +6,6 @@ import cats.Monad
 import cats.data.{EitherT, OptionT}
 import cats.instances.either._
 import cats.instances.vector._
-import cats.syntax.traverse._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import ch.epfl.bluebrain.nexus.commons.es.client.ElasticClient

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
@@ -8,15 +8,10 @@ import akka.http.scaladsl.model.{ContentType, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Route, Rejection => AkkaRejection}
 import cats.data.{EitherT, OptionT}
-import ch.epfl.bluebrain.nexus.commons.es.client.ElasticDecoder
-import ch.epfl.bluebrain.nexus.commons.http.HttpClient
-import ch.epfl.bluebrain.nexus.commons.http.HttpClient.withTaskUnmarshaller
-import ch.epfl.bluebrain.nexus.commons.types.search.QueryResults
 import ch.epfl.bluebrain.nexus.iam.client.types._
 import ch.epfl.bluebrain.nexus.kg._
 import ch.epfl.bluebrain.nexus.kg.async.DistributedCache
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig
-import ch.epfl.bluebrain.nexus.kg.config.AppConfig.HttpConfig
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig.tracing._
 import ch.epfl.bluebrain.nexus.kg.config.Contexts._
 import ch.epfl.bluebrain.nexus.kg.directives.AuthDirectives._
@@ -25,7 +20,6 @@ import ch.epfl.bluebrain.nexus.kg.directives.PathDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.ProjectDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.QueryDirectives._
 import ch.epfl.bluebrain.nexus.kg.marshallers.instances._
-import ch.epfl.bluebrain.nexus.kg.resources.ElasticDecoders.resourceIdDecoder
 import ch.epfl.bluebrain.nexus.kg.resources.Rejection.NotFound
 import ch.epfl.bluebrain.nexus.kg.resources._
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.Attachment.BinaryDescription
@@ -216,12 +210,6 @@ private[routes] class ResourceRoutes(resources: Resources[Task], schema: Absolut
         }
       }
     }
-
-  private implicit def qrsClient(implicit wrapped: LabeledProject,
-                                 http: HttpConfig): HttpClient[Task, QueryResults[AbsoluteIri]] = {
-    implicit val elasticDec = ElasticDecoder(resourceIdDecoder)
-    withTaskUnmarshaller[QueryResults[AbsoluteIri]]
-  }
 
   private val simultaneousParamsRejection: AkkaRejection =
     validationRejection("'rev' and 'tag' query parameters cannot be present simultaneously.")

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
@@ -31,6 +31,7 @@ import ch.epfl.bluebrain.nexus.kg.resources.Rejection.{NotFound, UnexpectedState
 import ch.epfl.bluebrain.nexus.kg.resources._
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.AttachmentStore
 import ch.epfl.bluebrain.nexus.kg.resources.attachment.AttachmentStore.{AkkaIn, AkkaOut}
+import ch.epfl.bluebrain.nexus.kg.search.QueryResultEncoder._
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import ch.epfl.bluebrain.nexus.rdf.syntax.circe.context._
 import com.github.ghik.silencer.silent
@@ -174,14 +175,22 @@ class ResourcesRoutes(resources: Resources[Task])(implicit cache: DistributedCac
   private def schema(implicit token: Option[AuthToken]): Route =
     ResourceRoutes(resources, shaclSchemaUri, "schemas")
 
-  private def resource(implicit token: Option[AuthToken]): Route =
+  private def resource(implicit token: Option[AuthToken]): Route = {
+    val resourceRead = Permissions(Permission(s"resources/read"), Permission(s"resources/manage"))
     (pathPrefix("resources") & project) { implicit wrapped =>
       acls.apply { implicit acls =>
-        pathPrefix(IdSegment) { schema =>
-          new ResourceRoutes(resources, schema, "resources").routes
-        }
+        (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
+          (deprecated, pagination) =>
+            trace(s"listResources") {
+              complete(cache.views(wrapped.ref).flatMap(v => resources.list(v, deprecated, pagination)).runAsync)
+            }
+        } ~
+          pathPrefix(IdSegment) { schema =>
+            new ResourceRoutes(resources, schema, "resources").routes
+          }
       }
     }
+  }
 
   private def filterDeprecated[A: DeprecatedId](set: Task[Set[A]], deprecated: Option[Boolean]): Task[List[A]] =
     set.map(s => deprecated.map(d => s.filter(_.deprecated == d)).getOrElse(s).toList)

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourcesRoutes.scala
@@ -176,12 +176,12 @@ class ResourcesRoutes(resources: Resources[Task])(implicit cache: DistributedCac
     ResourceRoutes(resources, shaclSchemaUri, "schemas")
 
   private def resource(implicit token: Option[AuthToken]): Route = {
-    val resourceRead = Permissions(Permission(s"resources/read"), Permission(s"resources/manage"))
+    val resourceRead = Permissions(Permission("resources/read"), Permission("resources/manage"))
     (pathPrefix("resources") & project) { implicit wrapped =>
       acls.apply { implicit acls =>
         (get & parameter('deprecated.as[Boolean].?) & paginated & hasPermissionInAcl(resourceRead) & pathEndOrSingleSlash) {
           (deprecated, pagination) =>
-            trace(s"listResources") {
+            trace("listResources") {
               complete(cache.views(wrapped.ref).flatMap(v => resources.list(v, deprecated, pagination)).runAsync)
             }
         } ~

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/package.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/package.scala
@@ -1,12 +1,31 @@
 package ch.epfl.bluebrain.nexus.kg
 
+import akka.stream.ActorMaterializer
 import ch.epfl.bluebrain.nexus.admin.client.types.Project
+import ch.epfl.bluebrain.nexus.commons.es.client.ElasticDecoder
+import ch.epfl.bluebrain.nexus.commons.http.HttpClient
+import ch.epfl.bluebrain.nexus.commons.http.HttpClient.{withTaskUnmarshaller, UntypedHttpClient}
+import ch.epfl.bluebrain.nexus.commons.types.search.QueryResults
+import ch.epfl.bluebrain.nexus.kg.config.AppConfig.HttpConfig
 import ch.epfl.bluebrain.nexus.kg.directives.LabeledProject
-import ch.epfl.bluebrain.nexus.kg.resources.ProjectLabel
+import ch.epfl.bluebrain.nexus.kg.marshallers.instances._
+import ch.epfl.bluebrain.nexus.kg.resources.ElasticDecoders.resourceIdDecoder
+import ch.epfl.bluebrain.nexus.kg.resources._
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
 
 package object routes {
 
   private[routes] implicit def toProject(implicit value: LabeledProject): Project           = value.project
   private[routes] implicit def toProjectLabel(implicit value: LabeledProject): ProjectLabel = value.label
+
+  private[routes] implicit def qrsClient(implicit httpClient: UntypedHttpClient[Task],
+                                         mt: ActorMaterializer,
+                                         wrapped: LabeledProject,
+                                         http: HttpConfig): HttpClient[Task, QueryResults[AbsoluteIri]] = {
+    implicit val elasticDec = ElasticDecoder(resourceIdDecoder)
+    withTaskUnmarshaller[QueryResults[AbsoluteIri]]
+  }
 
 }

--- a/src/test/resources/view/elasticview-wrong-mapping.json
+++ b/src/test/resources/view/elasticview-wrong-mapping.json
@@ -1,0 +1,16 @@
+{
+  "@id": "http://example.com/id",
+  "@type": [
+    "View",
+    "ElasticView",
+    "Alpha"
+  ],
+  "uuid": "3aa14a1a-81e7-4147-8306-136d8270bb01",
+  "resourceSchemas": [
+    "nxv:Schema",
+    "nxv:Resource"
+  ],
+  "resourceTag": "one",
+  "sourceAsText": true,
+  "mapping": "{\"mappings\": {\"{{docType}}\": {\"properties\": {\"@type\": {\"type\": \"keyword\"}, \"@id\": {\"type\": \"keyword\"}, \"_rev\": {\"type\": \"long\"}, \"_deprecated\": {\"type\": \"boolean\"}, \"_createdAt\": {\"type\": \"date\"}, \"_updatedAt\": {\"type\": \"date\"}, \"_createdBy\": {\"type\": \"keyword\"}, \"_updatedBy\": {\"type\": \"keyword\"}, \"_constrainedBy\": {\"type\": \"keyword\"}, \"_original_source\": {\"type\": \"text\"} }, \"dynamic\": false } } }"
+}

--- a/src/test/resources/view/elasticview.json
+++ b/src/test/resources/view/elasticview.json
@@ -12,5 +12,5 @@
   ],
   "resourceTag": "one",
   "sourceAsText": true,
-  "mapping": "{\"mappings\": {\"{{docType}}\": {\"properties\": {\"@type\": {\"type\": \"keyword\"}, \"@id\": {\"type\": \"keyword\"}, \"_rev\": {\"type\": \"long\"}, \"_deprecated\": {\"type\": \"boolean\"}, \"_createdAt\": {\"type\": \"date\"}, \"_updatedAt\": {\"type\": \"date\"}, \"_createdBy\": {\"type\": \"keyword\"}, \"_updatedBy\": {\"type\": \"keyword\"}, \"_constrainedBy\": {\"type\": \"keyword\"}, \"_original_source\": {\"type\": \"text\"} }, \"dynamic\": false } } }"
+  "mapping": "{\"properties\": {\"@type\": {\"type\": \"keyword\"}, \"@id\": {\"type\": \"keyword\"}, \"_rev\": {\"type\": \"long\"}, \"_deprecated\": {\"type\": \"boolean\"}, \"_createdAt\": {\"type\": \"date\"}, \"_updatedAt\": {\"type\": \"date\"}, \"_createdBy\": {\"type\": \"keyword\"}, \"_updatedBy\": {\"type\": \"keyword\"}, \"_constrainedBy\": {\"type\": \"keyword\"}, \"_original_source\": {\"type\": \"text\"} }, \"dynamic\": false }"
 }

--- a/src/test/resources/view/view-list-resp.json
+++ b/src/test/resources/view/view-list-resp.json
@@ -14,43 +14,39 @@
         "Alpha"
       ],
       "mapping": {
-        "mappings": {
-          "{{docType}}": {
-            "properties": {
-              "@type": {
-                "type": "keyword"
-              },
-              "@id": {
-                "type": "keyword"
-              },
-              "_rev": {
-                "type": "long"
-              },
-              "_deprecated": {
-                "type": "boolean"
-              },
-              "_createdAt": {
-                "type": "date"
-              },
-              "_updatedAt": {
-                "type": "date"
-              },
-              "_createdBy": {
-                "type": "keyword"
-              },
-              "_updatedBy": {
-                "type": "keyword"
-              },
-              "_constrainedBy": {
-                "type": "keyword"
-              },
-              "_original_source": {
-                "type": "text"
-              }
-            },
-            "dynamic": false
+        "properties": {
+          "@type": {
+            "type": "keyword"
+          },
+          "@id": {
+            "type": "keyword"
+          },
+          "_rev": {
+            "type": "long"
+          },
+          "_deprecated": {
+            "type": "boolean"
+          },
+          "_createdAt": {
+            "type": "date"
+          },
+          "_updatedAt": {
+            "type": "date"
+          },
+          "_createdBy": {
+            "type": "keyword"
+          },
+          "_updatedBy": {
+            "type": "keyword"
+          },
+          "_constrainedBy": {
+            "type": "keyword"
+          },
+          "_original_source": {
+            "type": "text"
           }
-        }
+        },
+        "dynamic": false
       },
       "includeMetadata": false,
       "resourceSchemas": [

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/indexing/ViewIndexerSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/indexing/ViewIndexerSpec.scala
@@ -70,7 +70,7 @@ class ViewIndexerSpec
     val json      = jsonContentOf("/view/sparqlview.json").appendContextOf(viewCtx)
     val resource  = ResourceF.simpleF(id, json, rev = 2, schema = schema, types = types)
     val resourceV = simpleV(id, json, rev = 2, schema = schema, types = types)
-    val view      = View(resourceV).value
+    val view      = View(resourceV).right.value
     val ev        = Created(id, 2L, schema, types, json, clock.instant(), Anonymous)
 
     "index a view" in {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
@@ -452,20 +452,26 @@ class ResourceRoutesSpec
             isA[HttpClient[Task, QueryResults[AbsoluteIri]]],
             isA[ElasticClient[Task]]
           )
-        ).thenReturn(
-          Task.pure(
-            UnscoredQueryResults(
-              5,
-              List(
-                UnscoredQueryResult(reprId(1)),
-                UnscoredQueryResult(reprId(2)),
-                UnscoredQueryResult(reprId(3)),
-                UnscoredQueryResult(reprId(4)),
-                UnscoredQueryResult(reprId(5))
-              )
-            ))
-        )
+        ).thenReturn(Task.pure(UnscoredQueryResults(5, List.range(1, 5).map(i => UnscoredQueryResult(reprId(i))))))
         Get(s"/v1/resources/$account/$project/resource") ~> addCredentials(oauthToken) ~> routes ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[Json] shouldEqual listingResponse()
+        }
+      }
+
+      "list resources" in new Ctx {
+        def reprId(i: Int): AbsoluteIri =
+          url"${appConfig.http.publicUri.copy(
+            path = appConfig.http.publicUri.path / "resources" / account / project / "resource" / s"resource:$i")}".value
+
+        when(
+          resources.list(mEq(Set(defaultEsView, defaultSQLView)), mEq(None), mEq(Pagination(0, 20)))(
+            isA[HttpClient[Task, QueryResults[AbsoluteIri]]],
+            isA[ElasticClient[Task]]
+          )
+        ).thenReturn(Task.pure(UnscoredQueryResults(5, List.range(1, 5).map(i => UnscoredQueryResult(reprId(i))))))
+
+        Get(s"/v1/resources/$account/$project") ~> addCredentials(oauthToken) ~> routes ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[Json] shouldEqual listingResponse()
         }

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
@@ -452,7 +452,7 @@ class ResourceRoutesSpec
             isA[HttpClient[Task, QueryResults[AbsoluteIri]]],
             isA[ElasticClient[Task]]
           )
-        ).thenReturn(Task.pure(UnscoredQueryResults(5, List.range(1, 5).map(i => UnscoredQueryResult(reprId(i))))))
+        ).thenReturn(Task.pure(UnscoredQueryResults(5, List.range(1, 6).map(i => UnscoredQueryResult(reprId(i))))))
         Get(s"/v1/resources/$account/$project/resource") ~> addCredentials(oauthToken) ~> routes ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[Json] shouldEqual listingResponse()
@@ -469,7 +469,7 @@ class ResourceRoutesSpec
             isA[HttpClient[Task, QueryResults[AbsoluteIri]]],
             isA[ElasticClient[Task]]
           )
-        ).thenReturn(Task.pure(UnscoredQueryResults(5, List.range(1, 5).map(i => UnscoredQueryResult(reprId(i))))))
+        ).thenReturn(Task.pure(UnscoredQueryResults(5, List.range(1, 6).map(i => UnscoredQueryResult(reprId(i))))))
 
         Get(s"/v1/resources/$account/$project") ~> addCredentials(oauthToken) ~> routes ~> check {
           status shouldEqual StatusCodes.OK


### PR DESCRIPTION
This will check that `mapping` value contains the allowed keys and will prevent the client from setting any other configuration option during elasticsearch initialization. The provided payload on the `mapping` value will be injected during index initialization as follows:
```json
{
   "mappings": {
      "doc" : {customerPayload}
   }
}
```