### PR TITLE
Fixed underscore routes

### DIFF
--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectives.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectives.scala
@@ -3,7 +3,7 @@ package ch.epfl.bluebrain.nexus.kg.directives
 import akka.http.scaladsl.common.{NameOptionReceptacle, NameReceptacle}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.ParameterDirectives.ParamDefAux
-import akka.http.scaladsl.server.{Directive0, Directive1, ValidationRejection}
+import akka.http.scaladsl.server.{Directive0, Directive1, MalformedQueryParamRejection}
 import ch.epfl.bluebrain.nexus.admin.client.types.Project
 import ch.epfl.bluebrain.nexus.commons.types.search.Pagination
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig.PaginationConfig
@@ -29,8 +29,10 @@ object QueryDirectives {
   def notParameter[A](param: NameReceptacle[A])(
       implicit paramAux: ParamDefAux[NameOptionReceptacle[A], Directive1[Option[A]]]): Directive0 = {
     parameter(param.?).flatMap {
-      case Some(_) => reject(ValidationRejection(s"the provided query parameter '${param.name}' should not be present"))
-      case _       => pass
+      case Some(_) =>
+        reject(MalformedQueryParamRejection(param.name, "the provided query parameter should not be present"))
+      case _ =>
+        pass
     }
   }
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectives.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectives.scala
@@ -26,7 +26,7 @@ object QueryDirectives {
     * @param param the parameter
     * @tparam A the type of the parameter
     */
-  def notParameter[A](param: NameReceptacle[A])(
+  def noParameter[A](param: NameReceptacle[A])(
       implicit paramAux: ParamDefAux[NameOptionReceptacle[A], Directive1[Option[A]]]): Directive0 = {
     parameter(param.?).flatMap {
       case Some(_) =>

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/Indexing.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/Indexing.scala
@@ -94,7 +94,7 @@ private class Indexing(resources: Resources[Task], cache: Caches[Task], coordina
   def startAdminStream(): Unit = {
 
     def handle(event: Event): Task[Unit] = {
-      logger.info(s"Handling admin event: '$event'")
+      logger.debug(s"Handling admin event: '$event'")
       event match {
         case OrganizationDeprecated(uuid, _, _, _) =>
           coordinator.stop(OrganizationRef(uuid))

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/CommonRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/CommonRoutes.scala
@@ -76,7 +76,7 @@ private[routes] abstract class CommonRoutes(
   def routes: Route
 
   def create(schema: Ref): Route =
-    (post & notParameter('rev.as[Long]) & projectNotDeprecated & pathEndOrSingleSlash & hasPermission(writePermission)) {
+    (post & noParameter('rev.as[Long]) & projectNotDeprecated & pathEndOrSingleSlash & hasPermission(writePermission)) {
       entity(as[Json]) { source =>
         trace(s"create$resourceName") {
           complete(Created -> resources.create(project.ref, project.base, schema, transform(source)).value.runToFuture)
@@ -85,7 +85,7 @@ private[routes] abstract class CommonRoutes(
     }
 
   def create(id: AbsoluteIri, schema: Ref): Route =
-    (put & notParameter('rev.as[Long]) & projectNotDeprecated & pathEndOrSingleSlash & hasPermission(writePermission)) {
+    (put & noParameter('rev.as[Long]) & projectNotDeprecated & pathEndOrSingleSlash & hasPermission(writePermission)) {
       entity(as[Json]) { source =>
         trace(s"create$resourceName") {
           complete(Created -> resources.create(Id(project.ref, id), schema, transform(source)).value.runToFuture)

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/FileRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/FileRoutes.scala
@@ -58,7 +58,7 @@ class FileRoutes private[routes] (resources: Resources[Task], acls: AccessContro
   }
 
   override def create(id: AbsoluteIri, schema: Ref): Route =
-    (put & projectNotDeprecated & hasPermission(writePermission) & pathEndOrSingleSlash) {
+    (put & projectNotDeprecated & pathEndOrSingleSlash & hasPermission(writePermission)) {
       fileUpload("file") {
         case (metadata, byteSource) =>
           val description = FileDescription(metadata.fileName, metadata.contentType.value)
@@ -70,7 +70,7 @@ class FileRoutes private[routes] (resources: Resources[Task], acls: AccessContro
     }
 
   override def create(schema: Ref): Route =
-    (post & projectNotDeprecated & hasPermission(writePermission) & pathEndOrSingleSlash) {
+    (post & projectNotDeprecated & pathEndOrSingleSlash & hasPermission(writePermission)) {
       fileUpload("file") {
         case (metadata, byteSource) =>
           val description = FileDescription(metadata.fileName, metadata.contentType.value)
@@ -81,7 +81,7 @@ class FileRoutes private[routes] (resources: Resources[Task], acls: AccessContro
     }
 
   override def update(id: AbsoluteIri, schemaOpt: Option[Ref]): Route =
-    (put & parameter('rev.as[Long]) & projectNotDeprecated & hasPermission(writePermission) & pathEndOrSingleSlash) {
+    (put & parameter('rev.as[Long]) & projectNotDeprecated & pathEndOrSingleSlash & hasPermission(writePermission)) {
       rev =>
         fileUpload("file") {
           case (metadata, byteSource) =>
@@ -106,7 +106,7 @@ class FileRoutes private[routes] (resources: Resources[Task], acls: AccessContro
     }
 
   private def getFile(id: AbsoluteIri): Route =
-    (get & parameter('rev.as[Long].?) & parameter('tag.?) & hasPermission(readPermission) & pathEndOrSingleSlash) {
+    (get & parameter('rev.as[Long].?) & parameter('tag.?) & pathEndOrSingleSlash & hasPermission(readPermission)) {
       (revOpt, tagOpt) =>
         val result = (revOpt, tagOpt) match {
           case (Some(_), Some(_)) => Future.successful(Left(simultaneousParamsRejection): RejectionOrFile)

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResolverRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResolverRoutes.scala
@@ -31,8 +31,8 @@ class ResolverRoutes private[routes] (resources: Resources[Task], acls: AccessCo
     create(resolverRef) ~ list(resolverRefOpt) ~
       pathPrefix(IdSegment) { id =>
         concat(
-          update(id, resolverRefOpt),
           create(id, resolverRef),
+          update(id, resolverRefOpt),
           tag(id, resolverRefOpt),
           deprecate(id, resolverRefOpt),
           fetch(id, resolverRefOpt),

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutes.scala
@@ -36,14 +36,13 @@ class ResourceRoutes private[routes] (resources: Resources[Task], acls: AccessCo
         create(schema.ref) ~ list(Some(schema.ref)) ~
           pathPrefix(IdSegment) { id =>
             concat(
-              update(id, Some(schema.ref)),
               create(id, schema.ref),
+              update(id, Some(schema.ref)),
               tag(id, Some(schema.ref)),
               deprecate(id, Some(schema.ref)),
               fetch(id, Some(schema.ref)),
               tags(id, Some(schema.ref))
             )
           }
-    }
-
+    } ~ create(resourceRef)
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/SchemaRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/SchemaRoutes.scala
@@ -26,8 +26,8 @@ class SchemaRoutes private[routes] (resources: Resources[Task], acls: AccessCont
     create(shaclRef) ~ list(shaclRefOpt) ~
       pathPrefix(IdSegment) { id =>
         concat(
-          update(id, shaclRefOpt),
           create(id, shaclRef),
+          update(id, shaclRefOpt),
           tag(id, shaclRefOpt),
           deprecate(id, shaclRefOpt),
           fetch(id, shaclRefOpt),

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/UnderscoreRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/UnderscoreRoutes.scala
@@ -31,19 +31,18 @@ class UnderscoreRoutes private[routes] (resources: Resources[Task], acls: Access
 
   private implicit val viewCache: ViewCache[Task] = cache.view
 
-  def routes: Route = {
+  def routes: Route =
     create(resourceRef) ~ list(None) ~
       pathPrefix(IdSegment) { id =>
         concat(
+          create(id, resourceRef),
           update(id),
-          create(id),
           tag(id),
           deprecate(id),
           fetch(id),
           tags(id)
         )
       }
-  }
 
   private case class ResourceType(routes: CommonRoutes, schema: Ref)
 
@@ -59,11 +58,6 @@ class UnderscoreRoutes private[routes] (resources: Resources[Task], acls: Access
       }
       .value
       .runToFuture
-
-  private def create(id: AbsoluteIri): Route = onSuccess(fetchType(id)) {
-    case Some(ResourceType(rt, schema)) => rt.create(id, schema)
-    case None                           => complete(NotFound(id.ref): Rejection)
-  }
 
   private def update(id: AbsoluteIri): Route = onSuccess(fetchType(id)) {
     case Some(ResourceType(rt, schema)) => rt.update(id, Some(schema))

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
@@ -473,10 +473,14 @@ class ResourceRoutesSpec
             projectMatcher,
             isA[AdditionalValidation[Task]])).thenReturn(EitherT.rightT[Task, Rejection](
           ResourceF.simpleF(id, ctx, created = subject, updated = subject, schema = schemaRef)))
-
-        Post(s"/v1/resources/$organization/$project/resource", ctx) ~> addCredentials(oauthToken) ~> routes ~> check {
-          status shouldEqual StatusCodes.Created
-          responseAs[Json] shouldEqual ctxResponse
+        val endpoints = List(s"/v1/resources/$organization/$project/resource",
+                             s"/v1/resources/$organization/$project/_",
+                             s"/v1/resources/$organization/$project")
+        forAll(endpoints) { endpoint =>
+          Post(endpoint, ctx) ~> addCredentials(oauthToken) ~> routes ~> check {
+            status shouldEqual StatusCodes.Created
+            responseAs[Json] shouldEqual ctxResponse
+          }
         }
       }
 


### PR DESCRIPTION
Changed order of directives in routes. The order must be as follows:
1. HTTP path
2. HTTP verb
3. HTTP query params (if present)
4. acls check
5. entity unmarshalling (entity(as[Json]))