### PR TITLE
Fixed ddata based indexing serialization preventing clustering

### DIFF
--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -2,6 +2,7 @@ akka {
 
   http {
     server.parsing.max-content-length = 10g
+    server.parsing.max-content-length = ${?AKKA_HTTP_MAX_CONTENT_LENGTH}
     host-connection-pool  {
       max-connections   = 16
       max-connections   = ${?AKKA_HTTP_MAX_CONNECTIONS}
@@ -42,39 +43,43 @@ akka {
     allow-java-serialization = off
 
     serializers {
-      circeEvent  = "ch.epfl.bluebrain.nexus.kg.serializers.Serializer$EventSerializer"
-      kryo        = "com.romix.akka.serialization.kryo.KryoSerializer"
+      circeEvent = "ch.epfl.bluebrain.nexus.kg.serializers.Serializer$EventSerializer"
+      kryo       = "com.romix.akka.serialization.kryo.KryoSerializer"
     }
 
     serialization-bindings {
-      "ch.epfl.bluebrain.nexus.kg.resources.Event"  = circeEvent
-      "ch.epfl.bluebrain.nexus.kg.resources.Command" = kryo,
-      "ch.epfl.bluebrain.nexus.kg.resources.State" = kryo,
-      "ch.epfl.bluebrain.nexus.kg.resources.ProjectLabel" = kryo
-      "ch.epfl.bluebrain.nexus.kg.indexing.View$SingleView" = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.RevisionedValue" = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg" = kryo
-      "ch.epfl.bluebrain.nexus.iam.client.types.AccessControlLists" = kryo
-      "ch.epfl.bluebrain.nexus.sourcing.akka.Msg" = kryo
+      # application values sent across the wire
+      "ch.epfl.bluebrain.nexus.kg.resources.Event"                       = circeEvent
+      "ch.epfl.bluebrain.nexus.kg.resources.Command"                     = kryo
+      "ch.epfl.bluebrain.nexus.kg.resources.State"                       = kryo
+      "ch.epfl.bluebrain.nexus.kg.resources.ProjectLabel"                = kryo
+      "ch.epfl.bluebrain.nexus.kg.indexing.View$SingleView"              = kryo
+      "ch.epfl.bluebrain.nexus.iam.client.types.AccessControlLists"      = kryo
+      "ch.epfl.bluebrain.nexus.sourcing.akka.Msg"                        = kryo
 
-      "ch.epfl.bluebrain.nexus.admin.client.types.Project" = kryo
-
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg"       = kryo
       "ch.epfl.bluebrain.nexus.service.indexer.stream.StreamCoordinator$Start" = kryo
       "ch.epfl.bluebrain.nexus.service.indexer.stream.StreamCoordinator$Stop$" = kryo
 
-      "ch.epfl.bluebrain.nexus.rdf.Iri$AbsoluteIri" = kryo
+      # key value store types
+      "ch.epfl.bluebrain.nexus.rdf.Iri$AbsoluteIri"                        = kryo
+      "ch.epfl.bluebrain.nexus.rdf.Iri$Path"                               = kryo
+      "ch.epfl.bluebrain.nexus.iam.client.types.ResourceAccessControlList" = kryo
+      "ch.epfl.bluebrain.nexus.admin.client.types.Project"                 = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.RevisionedValue"                   = kryo
+      "java.util.UUID"                                                     = kryo
 
-      "scala.runtime.BoxedUnit" = kryo
+      # generic values sent across the wire
+      "scala.runtime.BoxedUnit"        = kryo
       "scala.collection.immutable.Set" = kryo
-
-      "akka.actor.Status$Failure" = kryo
-      "akka.actor.Status$Success" = kryo
-      "java.util.UUID" = kryo
+      "akka.actor.Status$Failure"      = kryo
+      "akka.actor.Status$Success"      = kryo
     }
   }
 
   cluster {
     min-nr-of-members = 1
+    min-nr-of-members = ${?CLUSTER_MIN_NR_OF_MEMBERS}
     sharding.state-store-mode = ddata
   }
 


### PR DESCRIPTION
The types `java.util.UUID`, `ResourceAccessControlList` and `Path` were not listed in the serialization bindings. With java serialization disabled in a cluster setup the distributed data based implementation of the KeyValueStore would fail to ship updates across nodes.