### PR TITLE
Added default payload limit to maximum-frame-size, except for file uploads

### DIFF
--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -3,13 +3,13 @@ akka {
   http {
     server {
       parsing.max-content-length = ${akka.remote.netty.tcp.maximum-frame-size}
-      parsing.max-content-length = ${?AKKA_HTTP_MAX_CONTENT_LENGTH}
+      parsing.max-content-length = ${?AKKA_HTTP_SERVER_MAX_CONTENT_LENGTH}
       request-timeout = 1 minute
       request-timeout = ${?AKKA_HTTP_SERVER_REQ_TIMEOUT}
     }
     client {
       parsing.max-content-length = 10g
-      parsing.max-content-length = ${?AKKA_HTTP_MAX_CONTENT_LENGTH}
+      parsing.max-content-length = ${?AKKA_HTTP_CLIENT_MAX_CONTENT_LENGTH}
     }
     host-connection-pool  {
       max-connections   = 16

--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -2,7 +2,7 @@ akka {
 
   http {
     server {
-      parsing.max-content-length = 10g
+      parsing.max-content-length = ${akka.remote.netty.tcp.maximum-frame-size}
       parsing.max-content-length = ${?AKKA_HTTP_MAX_CONTENT_LENGTH}
       request-timeout = 1 minute
       request-timeout = ${?AKKA_HTTP_SERVER_REQ_TIMEOUT}

--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -71,6 +71,9 @@ app {
       write-permission = ${?DISK_WRITE_PERMISSION}
       show-location = false
       show-location = ${?DISK_SHOW_LOCATION}
+      # 10 GB (expressed in bytes)
+      max-file-size = 10737418240
+      max-file-size = ${?DISK_MAX_FILE_SIZE}
     }
     # Remote disk storage configuration
     remote-disk {
@@ -85,6 +88,9 @@ app {
       write-permission = ${?REMOTE_DISK_WRITE_PERMISSION}
       show-location = true
       show-location = ${?REMOTE_DISK_SHOW_LOCATION}
+      # 10 GB (expressed in bytes)
+      max-file-size = 10737418240
+      max-file-size = ${?REMOTE_DISK_MAX_FILE_SIZE}
     }
     # Amazon S3 storage configuration
     amazon {
@@ -96,6 +102,9 @@ app {
       write-permission = ${?S3_WRITE_PERMISSION}
       show-location = true
       show-location = ${?S3_SHOW_LOCATION}
+      # 10 GB (expressed in bytes)
+      max-file-size = 10737418240
+      max-file-size = ${?S3_MAX_FILE_SIZE}
     }
     # Password and salt used to encrypt credentials at rest
     password = "changeme"

--- a/src/main/resources/contexts/storage-context.json
+++ b/src/main/resources/contexts/storage-context.json
@@ -9,6 +9,10 @@
     "volume": "nxv:volume",
     "readPermission": "nxv:readPermission",
     "writePermission": "nxv:writePermission",
+    "maxFileSize": {
+      "@id": "nxv:maxFileSize",
+      "@type": "http://www.w3.org/2001/XMLSchema#long"
+    },
     "bucket": "nxv:bucket",
     "credentials": "nxv:credentials",
     "folder": "nxv:folder",

--- a/src/main/resources/schemas/storage.json
+++ b/src/main/resources/schemas/storage.json
@@ -40,6 +40,14 @@
           }
         },
         {
+          "path": "nxv:maxFileSize",
+          "name": "maxFileSize",
+          "description": "the maximum file size for uploaded entities",
+          "datatype": "xsd:long",
+          "minCount": 0,
+          "maxCount": 1
+        },
+        {
           "path": "nxv:default",
           "name": "default",
           "description": "Flag to determine whether or not the storage is a default storage",
@@ -86,6 +94,14 @@
           "sh:hasValue": {
             "@id": "nxv:RemoteDiskStorage"
           }
+        },
+        {
+          "path": "nxv:maxFileSize",
+          "name": "maxFileSize",
+          "description": "the maximum file size for uploaded entities",
+          "datatype": "xsd:long",
+          "minCount": 0,
+          "maxCount": 1
         },
         {
           "path": "nxv:default",
@@ -150,6 +166,14 @@
           "sh:hasValue": {
             "@id": "nxv:S3Storage"
           }
+        },
+        {
+          "path": "nxv:maxFileSize",
+          "name": "maxFileSize",
+          "description": "the maximum file size for uploaded entities",
+          "datatype": "xsd:long",
+          "minCount": 0,
+          "maxCount": 1
         },
         {
           "path": "nxv:default",

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/KgError.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/KgError.scala
@@ -32,6 +32,12 @@ object KgError {
   final case class InternalError(reason: String) extends KgError(reason)
 
   /**
+    * Signals that the file being uploaded is bigger than the allowed size limit
+    */
+  final case class FileSizeExceed(limit: Long, actual: Option[Long])
+      extends KgError(s"File maximum size exceed. Limit '$limit'")
+
+  /**
     * Signals that the operation is not supported
     */
   case object UnsupportedOperation extends KgError("The operation is not supported by the system.")
@@ -129,6 +135,7 @@ object KgError {
   }
 
   implicit val kgErrorStatusFrom: StatusFrom[KgError] = {
+    case _: FileSizeExceed                => StatusCodes.RequestEntityTooLarge
     case _: NotFound                      => StatusCodes.NotFound
     case _: ProjectNotFound               => StatusCodes.NotFound
     case _: OrganizationNotFound          => StatusCodes.NotFound

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
@@ -155,11 +155,13 @@ object AppConfig {
     * @param readPermission  the default permission required in order to download a file from a s3 storage
     * @param writePermission the default permission required in order to upload a file to a s3 storage
     * @param showLocation    flag to decide whether or not to show the absolute location of the files in the metadata response
+    * @param maxFileSize     the default maximum allowed file size (in bytes) for uploaded files
     */
   final case class S3StorageConfig(digestAlgorithm: String,
                                    readPermission: Permission,
                                    writePermission: Permission,
-                                   showLocation: Boolean)
+                                   showLocation: Boolean,
+                                   maxFileSize: Long)
 
   /**
     * Disk storage configuration
@@ -169,12 +171,14 @@ object AppConfig {
     * @param readPermission  the default permission required in order to download a file from a disk storage
     * @param writePermission the default permission required in order to upload a file to a disk storage
     * @param showLocation    flag to decide whether or not to show the absolute location of the files in the metadata response
+    * @param maxFileSize     the default maximum allowed file size (in bytes) for uploaded files
     */
   final case class DiskStorageConfig(volume: Path,
                                      digestAlgorithm: String,
                                      readPermission: Permission,
                                      writePermission: Permission,
-                                     showLocation: Boolean)
+                                     showLocation: Boolean,
+                                     maxFileSize: Long)
 
   /**
     * Remote Disk storage configuration
@@ -184,13 +188,15 @@ object AppConfig {
     * @param readPermission     the default permission required in order to download a file from a disk storage
     * @param writePermission    the default permission required in order to upload a file to a disk storage
     * @param showLocation       flag to decide whether or not to show the absolute location of the files in the metadata response
+    * @param maxFileSize        the default maximum allowed file size (in bytes) for uploaded files
     */
   final case class RemoteDiskStorageConfig(defaultEndpoint: Uri,
                                            defaultCredentials: Option[AuthToken],
                                            digestAlgorithm: String,
                                            readPermission: Permission,
                                            writePermission: Permission,
-                                           showLocation: Boolean)
+                                           showLocation: Boolean,
+                                           maxFileSize: Long)
 
   /**
     * IAM config

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Vocabulary.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Vocabulary.scala
@@ -91,6 +91,7 @@ object Vocabulary {
     val volume          = PrefixMapping.prefix("volume")
     val readPermission  = PrefixMapping.prefix("readPermission")
     val writePermission = PrefixMapping.prefix("writePermission")
+    val maxFileSize     = PrefixMapping.prefix("maxFileSize")
 
     //Remote disk storage payload vocabulary
     val folder      = PrefixMapping.prefix("folder")

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/FileRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/FileRoutes.scala
@@ -58,7 +58,7 @@ class FileRoutes private[routes] (files: Files[Task], resources: Resources[Task]
       // Create file when id is not provided in the Uri (POST)
       (post & projectNotDeprecated & pathEndOrSingleSlash & storage) { storage =>
         concat(
-          fileUpload("file") {
+          (withSizeLimit(storage.maxFileSize) & fileUpload("file")) {
             case (metadata, byteSource) =>
               operationName(s"/${config.http.prefix}/files/{}/{}") {
                 Kamon.currentSpan().tag("file.operation", "upload").tag("resource.operation", "create")
@@ -113,7 +113,7 @@ class FileRoutes private[routes] (files: Files[Task], resources: Resources[Task]
           val resId = Id(project.ref, id)
           (hasPermission(storage.writePermission) & projectNotDeprecated) {
             concat(
-              fileUpload("file") {
+              (withSizeLimit(storage.maxFileSize) & fileUpload("file")) {
                 case (metadata, byteSource) =>
                   val description = FileDescription(metadata.fileName, metadata.contentType)
                   parameter('rev.as[Long].?) {

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageEncoder.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageEncoder.scala
@@ -61,6 +61,7 @@ object StorageEncoder {
     Set(
       (s, rdf.tpe, nxv.Storage),
       (s, nxv.deprecated, storage.deprecated),
+      (s, nxv.maxFileSize, storage.maxFileSize),
       (s, nxv.rev, storage.rev),
       (s, nxv.default, storage.default),
       (s, nxv.algorithm, storage.algorithm),

--- a/src/test/resources/storage/disk-meta.json
+++ b/src/test/resources/storage/disk-meta.json
@@ -8,6 +8,7 @@
   "volume" : "/tmp",
   "readPermission" : "disk/read",
   "writePermission" : "disk/write",
+  "maxFileSize" : 1000,
   "_algorithm" : "SHA-256",
   "_deprecated" : false,
   "_rev" : 1

--- a/src/test/resources/storage/diskPerms.json
+++ b/src/test/resources/storage/diskPerms.json
@@ -4,5 +4,6 @@
   "volume": "/tmp",
   "default": false,
   "readPermission": "{read}",
-  "writePermission": "{write}"
+  "writePermission": "{write}",
+  "maxFileSize": 30000
 }

--- a/src/test/resources/storage/remoteDisk-meta.json
+++ b/src/test/resources/storage/remoteDisk-meta.json
@@ -10,6 +10,7 @@
   "folder" : "folder",
   "readPermission" : "myRead",
   "writePermission" : "myWrite",
+  "maxFileSize" : 2000,
   "_deprecated" : false,
   "_rev" : 1,
   "_algorithm" : "SHA-256"

--- a/src/test/resources/storage/s3-meta.json
+++ b/src/test/resources/storage/s3-meta.json
@@ -8,6 +8,7 @@
   "default" : true,
   "readPermission" : "s3/read",
   "writePermission" : "s3/write",
+  "maxFileSize" : 3000,
   "_deprecated" : false,
   "_algorithm" : "MD5",
   "_rev" : 1

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/cache/StorageCacheSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/cache/StorageCacheSpec.scala
@@ -39,7 +39,7 @@ class StorageCacheSpec
   val lastId = url"http://example.com/lastA".value
   // initialInstant.minusSeconds(1L + genInt().toLong)
 
-  val tempStorage = DiskStorage(ref1, genIri, 1L, false, true, "alg", Paths.get("/tmp"), read, write)
+  val tempStorage = DiskStorage(ref1, genIri, 1L, false, true, "alg", Paths.get("/tmp"), read, write, 1024L)
 
   val lastStorageProj1 = tempStorage.copy(id = lastId)
   val lastStorageProj2 = tempStorage.copy(ref = ref2, id = lastId)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
@@ -28,9 +28,9 @@ class AppConfigSpec extends WordSpecLike with Matchers with OptionValues with Te
                                                           "cassandra-snapshot-store",
                                                           "cassandra-query-journal")
       appConfig.storage shouldEqual StorageConfig(
-        DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false),
-        RemoteDiskStorageConfig("http://localhost:8084/v1", None, "SHA-256", read, write, true),
-        S3StorageConfig("SHA-256", read, write, true),
+        DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false, 10737418240L),
+        RemoteDiskStorageConfig("http://localhost:8084/v1", None, "SHA-256", read, write, true, 10737418240L),
+        S3StorageConfig("SHA-256", read, write, true, 10737418240L),
         "changeme",
         "salt"
       )

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectivesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectivesSpec.scala
@@ -60,9 +60,9 @@ class QueryDirectivesSpec
     implicit val config = PaginationConfig(10, 50, 10000)
     implicit val storageConfig =
       StorageConfig(
-        DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false),
-        RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true),
-        S3StorageConfig("MD5", read, write, true),
+        DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false, 1024L),
+        RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+        S3StorageConfig("MD5", read, write, true, 1024L),
         "password",
         "salt"
       )

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/serializers/EventSerializerSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/serializers/EventSerializerSpec.scala
@@ -40,9 +40,9 @@ class EventSerializerSpec
   private final val serialization = SerializationExtension(system)
   private implicit val storageConfig =
     StorageConfig(
-      DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false),
-      RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true),
-      S3StorageConfig("MD5", read, write, true),
+      DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false, 1024L),
+      RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+      S3StorageConfig("MD5", read, write, true, 1024L),
       "password",
       "salt"
     )

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperationsSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperationsSpec.scala
@@ -25,9 +25,9 @@ class DiskStorageOperationsSpec
     with TestHelper {
 
   private implicit val sc: StorageConfig = StorageConfig(
-    DiskStorageConfig(Paths.get("/tmp"), "SHA-256", read, write, false),
-    RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true),
-    S3StorageConfig("MD5", read, write, true),
+    DiskStorageConfig(Paths.get("/tmp"), "SHA-256", read, write, false, 1024L),
+    RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+    S3StorageConfig("MD5", read, write, true, 1024L),
     "password",
     "salt"
   )

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperationsSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperationsSpec.scala
@@ -36,9 +36,9 @@ class RemoteDiskStorageOperationsSpec
   private implicit val mt: Materializer = ActorMaterializer()
 
   private implicit val sc: StorageConfig = StorageConfig(
-    DiskStorageConfig(Paths.get("/tmp"), "SHA-256", read, write, false),
-    RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true),
-    S3StorageConfig("MD5", read, write, true),
+    DiskStorageConfig(Paths.get("/tmp"), "SHA-256", read, write, false, 1024L),
+    RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+    S3StorageConfig("MD5", read, write, true, 1024L),
     "password",
     "salt"
   )
@@ -48,7 +48,7 @@ class RemoteDiskStorageOperationsSpec
     implicit val token: Option[AuthToken] = Some(AuthToken(cred))
     val path                              = Uri.Path(s"${genString()}/${genString()}")
     // format: off
-    val storage = RemoteDiskStorage(ProjectRef(genUUID), genIri, 1L, false, false, "SHA-256", endpoint, Some(cred.encrypt), genString(), Permission.unsafe(genString()), Permission.unsafe(genString()))
+    val storage = RemoteDiskStorage(ProjectRef(genUUID), genIri, 1L, false, false, "SHA-256", endpoint, Some(cred.encrypt), genString(), Permission.unsafe(genString()), Permission.unsafe(genString()), 1024L)
     val attributes = FileAttributes(s"$endpoint/${storage.folder}/$path", path, s"${genString()}.json", `application/json`, 12L, Digest("SHA-256", genString()))
     // format: on
   }

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperationsSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperationsSpec.scala
@@ -53,9 +53,9 @@ class S3StorageOperationsSpec
   private var client: AmazonS3 = _
 
   private implicit val sc: StorageConfig = StorageConfig(
-    DiskStorageConfig(Paths.get("/tmp"), "SHA-256", read, write, false),
-    RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true),
-    S3StorageConfig("MD5", readS3, writeS3, true),
+    DiskStorageConfig(Paths.get("/tmp"), "SHA-256", read, write, false, 1024L),
+    RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+    S3StorageConfig("MD5", readS3, writeS3, true, 1024L),
     "password",
     "salt"
   )
@@ -107,7 +107,8 @@ class S3StorageOperationsSpec
                   bucket,
                   S3Settings(None, Some(address), Some(region)),
                   readS3,
-                  writeS3)
+                  writeS3,
+                  1024L)
 
       val verify = new S3StorageOperations.Verify[IO](storage)
       val save   = new S3StorageOperations.Save[IO](storage)
@@ -159,7 +160,8 @@ class S3StorageOperationsSpec
                   bucket,
                   S3Settings(None, Some(address), Some(region)),
                   readS3,
-                  writeS3)
+                  writeS3,
+                  1024L)
 
       val verify = new S3StorageOperations.Verify[IO](storage)
       val link   = new S3StorageOperations.Link[IO](storage)
@@ -202,7 +204,8 @@ class S3StorageOperationsSpec
                   "foobar",
                   S3Settings(None, Some(address), Some(region)),
                   readS3,
-                  writeS3)
+                  writeS3,
+                  1024L)
 
       val verify = new S3StorageOperations.Verify[IO](storage)
       val save   = new S3StorageOperations.Save[IO](storage)
@@ -242,7 +245,8 @@ class S3StorageOperationsSpec
                   bucket,
                   S3Settings(None, Some(address), None),
                   readS3,
-                  writeS3)
+                  writeS3,
+                  1024L)
 
       val verify = new S3StorageOperations.Verify[IO](storage)
       verify.apply.ioValue shouldEqual Right(())
@@ -268,7 +272,8 @@ class S3StorageOperationsSpec
           "nexus-storage",
           S3Settings(Some(S3Credentials(ak, sk)), Some("http://minio.dev.nexus.ocp.bbp.epfl.ch"), None),
           readS3,
-          writeS3
+          writeS3,
+          1024L
         )
 
       val verify = new S3StorageOperations.Verify[IO](storage)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageSpec.scala
@@ -35,9 +35,9 @@ class StorageSpec
   val writeS3                = Permission.unsafe("s3/write")
   private implicit val storageConfig =
     StorageConfig(
-      DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", readDisk, writeDisk, false),
-      RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true),
-      S3StorageConfig("MD5", readS3, writeS3, true),
+      DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", readDisk, writeDisk, false, 1000L),
+      RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 2000L),
+      S3StorageConfig("MD5", readS3, writeS3, true, 3000L),
       "password",
       "salt"
     )
@@ -65,7 +65,7 @@ class StorageSpec
       "return a DiskStorage" in {
         val resource = simpleV(id, diskStorage, types = Set(nxv.Storage, nxv.DiskStorage))
         Storage(resource, encrypt = false).right.value shouldEqual
-          DiskStorage(projectRef, iri, 1L, false, false, "SHA-256", Paths.get("/tmp"), readDisk, writeDisk)
+          DiskStorage(projectRef, iri, 1L, false, false, "SHA-256", Paths.get("/tmp"), readDisk, writeDisk, 1000L)
       }
 
       "return a DiskStorage with custom readPermission and writePermission" in {
@@ -73,7 +73,16 @@ class StorageSpec
         val expectedRead  = Permission.unsafe("myRead")
         val expectedWrite = Permission.unsafe("myWrite")
         Storage(resource, encrypt = false).right.value shouldEqual
-          DiskStorage(projectRef, iri, 1L, false, false, "SHA-256", Paths.get("/tmp"), expectedRead, expectedWrite)
+          DiskStorage(projectRef,
+                      iri,
+                      1L,
+                      false,
+                      false,
+                      "SHA-256",
+                      Paths.get("/tmp"),
+                      expectedRead,
+                      expectedWrite,
+                      30000L)
       }
 
       "return a RemoteDiskStorage" in {
@@ -91,7 +100,8 @@ class StorageSpec
                             Some("credentials"),
                             "folder",
                             expectedRead,
-                            expectedWrite)
+                            expectedWrite,
+                            2000L)
       }
 
       "return a RemoteDiskStorage encrypted" in {
@@ -109,14 +119,25 @@ class StorageSpec
                             Some("credentials".encrypt),
                             "folder",
                             expectedRead,
-                            expectedWrite)
+                            expectedWrite,
+                            2000L)
       }
 
       "return an S3Storage" in {
         val resource = simpleV(id, s3Minimal, types = Set(nxv.Storage, nxv.S3Storage))
 
         Storage(resource, encrypt = false).right.value shouldEqual
-          S3Storage(projectRef, iri, 1L, false, true, "MD5", "bucket", S3Settings(None, None, None), readS3, writeS3)
+          S3Storage(projectRef,
+                    iri,
+                    1L,
+                    false,
+                    true,
+                    "MD5",
+                    "bucket",
+                    S3Settings(None, None, None),
+                    readS3,
+                    writeS3,
+                    3000L)
       }
 
       "return an S3Storage with credentials and region" in {
@@ -125,7 +146,7 @@ class StorageSpec
         val expectedRead  = Permission.unsafe("my/read")
         val expectedWrite = Permission.unsafe("my/write")
         Storage(resource, encrypt = false).right.value shouldEqual
-          S3Storage(projectRef, iri, 1L, false, true, "MD5", "bucket", settings, expectedRead, expectedWrite)
+          S3Storage(projectRef, iri, 1L, false, true, "MD5", "bucket", settings, expectedRead, expectedWrite, 3000L)
       }
 
       "return an S3Storage with encrypted credentials" in {
@@ -136,7 +157,7 @@ class StorageSpec
         val expectedRead  = Permission.unsafe("my/read")
         val expectedWrite = Permission.unsafe("my/write")
         Storage(resource, encrypt = true).right.value shouldEqual
-          S3Storage(projectRef, iri, 1L, false, true, "MD5", "bucket", settings, expectedRead, expectedWrite)
+          S3Storage(projectRef, iri, 1L, false, true, "MD5", "bucket", settings, expectedRead, expectedWrite, 3000L)
       }
 
       "fail on DiskStorage when types are wrong" in {
@@ -171,9 +192,9 @@ class StorageSpec
         val expectedRead  = Permission.unsafe("myRead")
         val expectedWrite = Permission.unsafe("myWrite")
         // format: off
-        val disk: Storage = DiskStorage(projectRef, iri, 1L, false, false, "SHA-256", Paths.get("/tmp"), readDisk, writeDisk)
-        val s3: Storage = S3Storage(projectRef, iri, 1L, false, true, "MD5", "bucket", S3Settings(None, None, None), readS3, writeS3)
-        val remote: Storage = RemoteDiskStorage(projectRef, iri, 1L, false, false, "SHA-256", "http://example.com/some", Some("credentials"), "folder", expectedRead, expectedWrite)
+        val disk: Storage = DiskStorage(projectRef, iri, 1L, false, false, "SHA-256", Paths.get("/tmp"), readDisk, writeDisk, 1000L)
+        val s3: Storage = S3Storage(projectRef, iri, 1L, false, true, "MD5", "bucket", S3Settings(None, None, None), readS3, writeS3, 3000L)
+        val remote: Storage = RemoteDiskStorage(projectRef, iri, 1L, false, false, "SHA-256", "http://example.com/some", Some("credentials"), "folder", expectedRead, expectedWrite, 2000L)
         // format: on
 
         forAll(


### PR DESCRIPTION
- Every resources' payload will be capped by the configuration property `akka.http.server.parsing.max-content-length` which points to the property `akka.remote.netty.tcp.maximum-frame-size`
- For file uploads, which are the exception, this is overridden by the directive `withSizeLimit`.

This is recommended by akka http
> So suggested setup is to have akka.http.parsing.max-content-length relatively low and use withSizeLimit directive for endpoints which expects bigger entities.

In order to control the file size on file uploads, a new property `maxFileSize` has been added to the storages.