### PR TITLE
Added async process to compute file digest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ scalafmt: {
 // Dependency versions
 val adminVersion                = "137f25ca"
 val commonsVersion              = "0.17.0"
-val storageVersion              = "51d26b08"
+val storageVersion              = "220fcaf5"
 val sourcingVersion             = "0.16.3"
 val akkaVersion                 = "2.5.23"
 val akkaCorsVersion             = "0.4.1"

--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -108,6 +108,8 @@ app {
     }
 
     # Digest retry configuration
+    # This setup will retry linearly starting at 1 second, capped to 10 seconds
+    # In the worse case, it will retry up to 2.7 hours
     digest-retry {
       # possible values are: "never", "once" and "exponential"
       strategy = "linear"
@@ -116,10 +118,11 @@ app {
       initial-delay = 300 milliseconds
       initial-delay = ${?DIGEST_FETCH_RETRY_INITIAL_DELAY}
       # the maximum delay applied to the retrying strategy
-      max-delay = 5 minutes
+      max-delay = 10 seconds
       max-delay = ${?DIGEST_FETCH_RETRY_MAX_DELAY}
       # maximum number of retries in case of failure (applicable only for strategy "exponential")
-      max-retries = 100
+
+      max-retries = 10000
       max-retries = ${?DIGEST_FETCH_RETRY_MAX_RETRIES}
       # the exponential factor (applicable only for strategy "exponential")
       factor = 0.2
@@ -202,6 +205,8 @@ app {
     }
 
     # Sparql indexing configuration
+    # This setup will retry exponentially starting at 500 millis, capped to 3 minutes
+    # In the worse case, it will retry up to almost 90 minutes
     indexing {
       # Maximum number of events taken on each batch
       batch = 10
@@ -219,10 +224,10 @@ app {
         initial-delay = 100 milliseconds
         initial-delay = ${?INDEXING_SPARQL_RETRY_INITIAL_DELAY}
         # the maximum delay applied to the retrying strategy
-        max-delay = 10 minutes
+        max-delay = 3 minutes
         max-delay = ${?INDEXING_SPARQL_RETRY_MAX_DELAY}
         # maximum number of retries in case of failure (applicable only for strategy "exponential")
-        max-retries = 7
+        max-retries = 30
         max-retries = ${?INDEXING_SPARQL_RETRY_MAX_RETRIES}
         # the exponential factor (applicable only for strategy "exponential")
         factor = 0.2
@@ -270,6 +275,8 @@ app {
     }
 
     # Elastic Search indexing configuration
+    # This setup will retry exponentially starting at 500 millis, capped to 3 minutes
+    # In the worse case, it will retry up to almost 90 minutes
     indexing {
       # Maximum number of events taken on each batch
       batch = 30
@@ -287,10 +294,10 @@ app {
         initial-delay = 100 milliseconds
         initial-delay = ${?INDEXING_ELASTICSEARCH_RETRY_INITIAL_DELAY}
         # the maximum delay applied to the retrying strategy
-        max-delay = 10 minutes
+        max-delay = 3 minutes
         max-delay = ${?INDEXING_ELASTICSEARCH_RETRY_MAX_DELAY}
         # maximum number of retries in case of failure (applicable only for strategy "exponential")
-        max-retries = 7
+        max-retries = 30
         max-retries = ${?INDEXING_ELASTICSEARCH_RETRY_MAX_RETRIES}
         # the exponential factor (applicable only for strategy "exponential")
         factor = 0.2
@@ -413,10 +420,10 @@ app {
         initial-delay = 100 milliseconds
         initial-delay = ${?INDEXING_KEY_VALUE_STORE_RETRY_INITIAL_DELAY}
         # the maximum delay applied to the retrying strategy
-        max-delay = 10 minutes
+        max-delay = 3 minutes
         max-delay = ${?INDEXING_KEY_VALUE_STORE_RETRY_MAX_DELAY}
         # maximum number of retries in case of failure (applicable only for strategy "exponential")
-        max-retries = 7
+        max-retries = 10
         max-retries = ${?INDEXING_KEY_VALUE_STORE_RETRY_MAX_RETRIES}
         # the exponential factor (applicable only for strategy "exponential")
         factor = 0.2

--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -106,6 +106,29 @@ app {
       max-file-size = 10737418240
       max-file-size = ${?S3_MAX_FILE_SIZE}
     }
+
+    # Digest retry configuration
+    digest-retry {
+      # possible values are: "never", "once" and "exponential"
+      strategy = "linear"
+      strategy = ${?DIGEST_FETCH_RETRY_STRATEGY}
+      # the initial delay before retrying that will be multiplied with the 'factor' for each attempt
+      initial-delay = 300 milliseconds
+      initial-delay = ${?DIGEST_FETCH_RETRY_INITIAL_DELAY}
+      # the maximum delay applied to the retrying strategy
+      max-delay = 5 minutes
+      max-delay = ${?DIGEST_FETCH_RETRY_MAX_DELAY}
+      # maximum number of retries in case of failure (applicable only for strategy "exponential")
+      max-retries = 100
+      max-retries = ${?DIGEST_FETCH_RETRY_MAX_RETRIES}
+      # the exponential factor (applicable only for strategy "exponential")
+      factor = 0.2
+      factor = ${?DIGEST_FETCH_RETRY_RANDOM_FACTOR}
+      # the linear increment (applicable only for strategy "linear")
+      increment = 1 second
+      increment = ${?DIGEST_FETCH_RETRY_INCREMENT}
+    }
+
     # Password and salt used to encrypt credentials at rest
     password = "changeme"
     password = ${?STORAGE_PASSWORD}

--- a/src/main/resources/contexts/digest-context.json
+++ b/src/main/resources/contexts/digest-context.json
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "nxv": "https://bluebrain.github.io/nexus/vocabulary/",
+    "value": "nxv:value",
+    "algorithm": "nxv:algorithm",
+    "UpdateDigest": "nxv:UpdateDigest"
+  },
+  "@id": "https://bluebrain.github.io/nexus/contexts/digest.json"
+}

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/Main.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/Main.scala
@@ -140,7 +140,7 @@ object Main {
         Projections[Task, Event].runSyncUnsafe(10 seconds)(Scheduler.global, CanBlock.permit)
       }
 
-      val projectCoordinator = Indexing.start(resources, storages, views, resolvers, indexers.adminClient)
+      val projectCoordinator = Indexing.start(resources, storages, views, resolvers, files, indexers.adminClient)
       val routes: Route      = Routes(resources, resolvers, views, storages, schemas, files, tags, projectCoordinator)
 
       val httpBinding = {

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
@@ -134,17 +134,19 @@ object AppConfig {
   /**
     * Storage configuration for the allowed storages
     *
-    * @param disk       the disk storage configuration
-    * @param remoteDisk the remote disk storage configuration
-    * @param amazon     the amazon S3 storage configuration
-    * @param password   the password used to encrypt credentials at rest
-    * @param salt       the associated salt
+    * @param disk        the disk storage configuration
+    * @param remoteDisk  the remote disk storage configuration
+    * @param amazon      the amazon S3 storage configuration
+    * @param password    the password used to encrypt credentials at rest
+    * @param salt        the associated salt
+    * @param digestRetry the digest retry configuration
     */
   final case class StorageConfig(disk: DiskStorageConfig,
                                  remoteDisk: RemoteDiskStorageConfig,
                                  amazon: S3StorageConfig,
                                  password: String,
-                                 salt: String) {
+                                 salt: String,
+                                 digestRetry: RetryStrategyConfig) {
     val derivedKey: SecretKey = Crypto.deriveKey(password, salt)
   }
 
@@ -267,6 +269,7 @@ object AppConfig {
 
   val iriResolution: Map[AbsoluteIri, Json] = Map(
     tagCtxUri         -> tagCtx,
+    digestCtxUri      -> digestCtx,
     resourceCtxUri    -> resourceCtx,
     shaclCtxUri       -> shaclCtx,
     resolverCtxUri    -> resolverCtx,

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Contexts.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Contexts.scala
@@ -11,6 +11,7 @@ object Contexts {
 
   val errorCtxUri: AbsoluteIri    = base + "error.json"
   val tagCtxUri: AbsoluteIri      = base + "tag.json"
+  val digestCtxUri: AbsoluteIri   = base + "digest.json"
   val resourceCtxUri: AbsoluteIri = base + "resource.json"
   val resolverCtxUri: AbsoluteIri = base + "resolver.json"
   val viewCtxUri: AbsoluteIri     = base + "view.json"
@@ -19,6 +20,7 @@ object Contexts {
   val searchCtxUri: AbsoluteIri   = base + "search.json"
 
   val tagCtx: Json      = jsonContentOf("/contexts/tags-context.json")
+  val digestCtx: Json   = jsonContentOf("/contexts/digest-context.json")
   val resourceCtx: Json = jsonContentOf("/contexts/resource-context.json")
   val resolverCtx: Json = jsonContentOf("/contexts/resolver-context.json")
   val viewCtx: Json     = jsonContentOf("/contexts/view-context.json")

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Vocabulary.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Vocabulary.scala
@@ -121,6 +121,7 @@ object Vocabulary {
     val paths = PrefixMapping.prefix("paths")
 
     // @type platform ids
+    val UpdateDigest               = PrefixMapping.prefix("UpdateDigest")
     val Schema                     = PrefixMapping.prefix("Schema")
     val File                       = PrefixMapping.prefix("File")
     val Resource                   = PrefixMapping.prefix("Resource")

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Command.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Command.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import ch.epfl.bluebrain.nexus.iam.client.types.Identity.Subject
 import ch.epfl.bluebrain.nexus.kg.config.Schemas._
 import ch.epfl.bluebrain.nexus.kg.config.Vocabulary._
-import ch.epfl.bluebrain.nexus.kg.resources.file.File.FileAttributes
+import ch.epfl.bluebrain.nexus.kg.resources.file.File.{Digest, FileAttributes}
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import io.circe.Json
@@ -143,6 +143,30 @@ object Command {
       * the schema that is used to constrain the resource
       */
     val schema: Ref = fileSchemaUri.ref
+
+    /**
+      * the collection of known resource types
+      */
+    val types: Set[AbsoluteIri] = Set(nxv.File.value)
+  }
+
+  /**
+    * An intent to update a file digest.
+    *
+    * @param id      the resource identifier
+    * @param storage the reference to the storage that is computing the file digest
+    * @param rev     the last known revision of the resource when this command was created
+    * @param value   the file digest
+    * @param instant the instant when this event was recorded
+    * @param subject the subject which generated this event
+    */
+  final case class UpdateFileDigest(id: Id[ProjectRef],
+                                    storage: StorageReference,
+                                    rev: Long,
+                                    value: Digest,
+                                    instant: Instant,
+                                    subject: Subject)
+      extends Command {
 
     /**
       * the collection of known resource types

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Event.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Event.scala
@@ -176,6 +176,33 @@ object Event {
   }
 
   /**
+    * A witness that a file digest has been updated.
+    *
+    * @param id           the resource identifier
+    * @param organization the organization resource identifier
+    * @param storage      the reference to the storage used to fetch the digest of the file
+    * @param rev          the revision that this event generated
+    * @param digest       the updated digest
+    * @param instant      the instant when this event was recorded
+    * @param subject      the identity which generated this event
+    */
+  final case class FileDigestUpdated(
+      id: Id[ProjectRef],
+      organization: OrganizationRef,
+      storage: StorageReference,
+      rev: Long,
+      digest: Digest,
+      instant: Instant,
+      subject: Subject
+  ) extends Event {
+
+    /**
+      * the collection of known resource types
+      */
+    val types: Set[AbsoluteIri] = Set(nxv.File.value)
+  }
+
+  /**
     * A witness that a file resource has been updated.
     *
     * @param id           the resource identifier

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Files.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Files.scala
@@ -17,11 +17,11 @@ import ch.epfl.bluebrain.nexus.kg.resources.Rejection.NotFound.notFound
 import ch.epfl.bluebrain.nexus.kg.resources.Rejection._
 import ch.epfl.bluebrain.nexus.kg.resources.Resources.generateId
 import ch.epfl.bluebrain.nexus.kg.resources.file.File
-import ch.epfl.bluebrain.nexus.kg.resources.file.File.{FileAttributes, FileDescription, LinkDescription}
+import ch.epfl.bluebrain.nexus.kg.resources.file.File.{Digest, FileAttributes, FileDescription, LinkDescription}
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
 import ch.epfl.bluebrain.nexus.kg.routes.SearchParams
 import ch.epfl.bluebrain.nexus.kg.storage.Storage
-import ch.epfl.bluebrain.nexus.kg.storage.Storage.StorageOperations.{Fetch, Link, Save}
+import ch.epfl.bluebrain.nexus.kg.storage.Storage.StorageOperations.{Fetch, FetchDigest, Link, Save}
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import io.circe.Json
 
@@ -58,6 +58,38 @@ class Files[F[_]: Effect: Timer](repo: Repo[F])(implicit storageCache: StorageCa
     EitherT
       .right(storage.save.apply(id, fileDesc, source))
       .flatMap(attr => repo.createFile(id, OrganizationRef(project.organizationUuid), storage.reference, attr))
+
+  /**
+    * Updates the digest of a file resource if it is not already present.
+    * The digest is fetched from the storage implementation and saved in the primary store
+    *
+    * @param id      the id of the resource
+    * @return either a rejection or the new resource representation in the F context
+    */
+  def updateDigestIfEmpty(id: ResId)(implicit subject: Subject, fetchDigest: FetchDigest[F]): RejOrResource[F] =
+    // format: off
+    for {
+      curr              <- repo.get(id, Some(fileRef)).toRight(notFound(id.ref))
+      currFile          <- EitherT.fromEither[F](curr.file.toRight(notFound(id.ref)))
+      (storageRef, attr) = currFile
+      storage           <- EitherT.fromOptionF(storageCache.get(id.parent, storageRef.id), UnexpectedState(storageRef.id.ref))
+      digest            <- if(attr.digest == Digest.empty) EitherT.right(storage.fetchDigest.apply(attr.path)) else EitherT.leftT[F, Digest](ResourceAlreadyExists(id.ref): Rejection)
+      _                 <- if(digest == Digest.empty) EitherT.leftT[F, Resource](FileDigestNotComputed(id.ref)) else EitherT.rightT[F, Rejection](())
+      updated           <- repo.updateFileDigest(id, storage.reference, curr.rev, digest)
+    } yield updated
+  // format: on
+
+  /**
+    * Updates the digest of a file resource.
+    *
+    * @param id      the id of the resource
+    * @param storage the storage reference
+    * @param rev     the last known revision of the resource
+    * @param digest  the digest of the file in a json format
+    * @return either a rejection or the new resource representation in the F context
+    */
+  def updateDigest(id: ResId, storage: Storage, rev: Long, digest: Json)(implicit subject: Subject): RejOrResource[F] =
+    EitherT.fromEither[F](Digest(id, digest)).flatMap(repo.updateFileDigest(id, storage.reference, rev, _))
 
   /**
     * Replaces a file resource.

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Rejection.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Rejection.scala
@@ -58,6 +58,13 @@ object Rejection {
       extends Rejection(s"Resource '${ref.show}' does not have a computed digest.")
 
   /**
+    * Signals an attempt to compute the digest for a file where the digest already exists.
+    *
+    * @param ref a reference to the resource
+    */
+  final case class FileDigestAlreadyExists(ref: Ref) extends Rejection(s"File '${ref.show}' digest already exists.")
+
+  /**
     * Signals an attempt to perform a request with an invalid payload.
     *
     * @param ref a reference to the resource
@@ -241,6 +248,7 @@ object Rejection {
     case _: ProjectsNotFound         => StatusCodes.NotFound
     case _: IncorrectRev             => StatusCodes.Conflict
     case _: ResourceAlreadyExists    => StatusCodes.Conflict
+    case _: FileDigestAlreadyExists  => StatusCodes.Conflict
     case _: InvalidIdentity          => StatusCodes.Unauthorized
   }
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Rejection.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Rejection.scala
@@ -50,6 +50,14 @@ object Rejection {
   final case class NotAFileResource(ref: Ref) extends Rejection(s"Resource '${ref.show}' is not a file resource.")
 
   /**
+    * Signals the missing digest computed for a file resource
+    *
+    * @param ref a reference to the resource
+    */
+  final case class FileDigestNotComputed(ref: Ref)
+      extends Rejection(s"Resource '${ref.show}' does not have a computed digest.")
+
+  /**
     * Signals an attempt to perform a request with an invalid payload.
     *
     * @param ref a reference to the resource
@@ -215,6 +223,7 @@ object Rejection {
   }
 
   implicit def statusCodeFrom: StatusFrom[Rejection] = StatusFrom {
+    case _: FileDigestNotComputed    => StatusCodes.BadRequest
     case _: ResourceIsDeprecated     => StatusCodes.BadRequest
     case _: IncorrectTypes           => StatusCodes.BadRequest
     case _: IllegalContextValue      => StatusCodes.BadRequest

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Repo.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/Repo.scala
@@ -125,11 +125,8 @@ class Repo[F[_]: Monad](agg: Agg[F], clock: Clock, toIdentifier: ResId => String
     * @param instant  an optionally provided operation instant
     * @return either a rejection or the new resource representation in the F context
     */
-  def updateFileDigest(id: ResId,
-                       storage: StorageReference,
-                       rev: Long,
-                       digest: Digest,
-                       instant: Instant = clock.instant)(implicit subject: Subject): EitherT[F, Rejection, Resource] =
+  def updateDigest(id: ResId, storage: StorageReference, rev: Long, digest: Digest, instant: Instant = clock.instant)(
+      implicit subject: Subject): EitherT[F, Rejection, Resource] =
     evaluate(id, UpdateFileDigest(id, storage, rev, digest, instant, subject))
 
   /**
@@ -297,7 +294,7 @@ object Repo {
         case _       => Left(ResourceAlreadyExists(c.id.ref))
       }
 
-    def updateFileDigest(c: UpdateFileDigest): Either[Rejection, FileDigestUpdated] =
+    def updateDigest(c: UpdateFileDigest): Either[Rejection, FileDigestUpdated] =
       state match {
         case Initial                      => Left(NotFound(c.id.ref))
         case s: Current if s.rev != c.rev => Left(IncorrectRev(c.id.ref, c.rev, s.rev))
@@ -351,7 +348,7 @@ object Repo {
     cmd match {
       case cmd: Create           => create(cmd)
       case cmd: CreateFile       => createFile(cmd)
-      case cmd: UpdateFileDigest => updateFileDigest(cmd)
+      case cmd: UpdateFileDigest => updateDigest(cmd)
       case cmd: UpdateFile       => updateFile(cmd)
       case cmd: Update           => update(cmd)
       case cmd: Deprecate        => deprecate(cmd)

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/file/File.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/file/File.scala
@@ -1,20 +1,27 @@
 package ch.epfl.bluebrain.nexus.kg.resources.file
 
+import java.security.MessageDigest
 import java.util.UUID
 
 import akka.http.scaladsl.model.{ContentType, Uri}
 import ch.epfl.bluebrain.nexus.commons.rdf.instances._
 import ch.epfl.bluebrain.nexus.iam.client.types.Permission
-import ch.epfl.bluebrain.nexus.kg.config.Contexts.storageCtx
+import ch.epfl.bluebrain.nexus.kg.config.Contexts._
 import ch.epfl.bluebrain.nexus.kg.config.Vocabulary.nxv
-import ch.epfl.bluebrain.nexus.kg.resources.Rejection.InvalidJsonLD
+import ch.epfl.bluebrain.nexus.kg.resources.Rejection.{InvalidJsonLD, InvalidResourceFormat}
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
 import ch.epfl.bluebrain.nexus.kg.resources.{nonEmpty, Rejection, ResId}
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import ch.epfl.bluebrain.nexus.rdf.Vocabulary.rdf
 import ch.epfl.bluebrain.nexus.rdf.encoder.GraphEncoder._
-import ch.epfl.bluebrain.nexus.rdf.encoder.NodeEncoder.stringEncoder
+import ch.epfl.bluebrain.nexus.rdf.encoder.NodeEncoder.{stringEncoder, EncoderResult}
+import ch.epfl.bluebrain.nexus.rdf.encoder.NodeEncoderError
+import ch.epfl.bluebrain.nexus.rdf.encoder.NodeEncoderError.IllegalConversion
 import ch.epfl.bluebrain.nexus.rdf.instances._
 import ch.epfl.bluebrain.nexus.rdf.syntax._
 import io.circe.Json
+
+import scala.util.Try
 
 object File {
 
@@ -103,6 +110,35 @@ object File {
     * @param value     the actual value of the digest of the file
     */
   final case class Digest(algorithm: String, value: String)
+  object Digest {
+
+    /**
+      * Attempts to constructs a Digest from the provided json
+      *
+      * @param resId the resource identifier
+      * @param json  the payload
+      * @return Right(digest) when successful and Left(rejection) when failed
+      */
+    final def apply(resId: ResId, json: Json): Either[Rejection, Digest] =
+      // format: off
+      for {
+        graph       <- (json deepMerge digestCtx).id(resId.value).asGraph(resId.value).left.map(_ => InvalidResourceFormat(resId.ref, "Empty or wrong Json-LD. Both 'algorithm' and 'value' fields must be present."))
+        cursor       = graph.cursor()
+        _           <- cursor.downField(rdf.tpe).focus.as[AbsoluteIri].flatMap(validType).left.map(_ => InvalidResourceFormat(resId.ref, "'@type' field does not have the right format."))
+        algorithm   <- cursor.downField(nxv.algorithm).focus.as[String].flatMap(validAlgorithm).left.map(_ => InvalidResourceFormat(resId.ref, "'algorithm' field does not have the right format."))
+        value       <- cursor.downField(nxv.value).focus.as[String].flatMap(nonEmpty(_, "value")).left.map(_ => InvalidResourceFormat(resId.ref, "'value' field does not have the right format."))
+      } yield Digest(algorithm, value)
+    // format: on
+
+    val empty: Digest = Digest("", "")
+
+    private def validType(iri: AbsoluteIri): EncoderResult[AbsoluteIri] =
+      if (iri == nxv.UpdateDigest.value) Right(iri) else Left(IllegalConversion(""))
+
+    private def validAlgorithm(s: String): EncoderResult[String] =
+      Try(MessageDigest.getInstance(s)).map(_ => s).toOption.toRight[NodeEncoderError](IllegalConversion(""))
+
+  }
 
   /**
     * The summary after the file has been stored

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperations.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperations.scala
@@ -12,7 +12,7 @@ import cats.implicits._
 import ch.epfl.bluebrain.nexus.kg.KgError
 import ch.epfl.bluebrain.nexus.kg.resources.ResId
 import ch.epfl.bluebrain.nexus.kg.resources.file.File._
-import ch.epfl.bluebrain.nexus.kg.storage.Storage.{DiskStorage, FetchFile, LinkFile, SaveFile, VerifyStorage}
+import ch.epfl.bluebrain.nexus.kg.storage.Storage._
 import journal.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -102,6 +102,15 @@ object DiskStorageOperations {
     */
   final class LinkDiskFile[F[_]]()(implicit F: Effect[F]) extends LinkFile[F] {
     override def apply(id: ResId, fileDesc: FileDescription, path: Uri.Path): F[FileAttributes] =
+      F.raiseError(KgError.UnsupportedOperation)
+  }
+
+  /**
+    * [[FetchFileDigest]] implementation for [[DiskStorage]] that always throws an error since this operation is not supported.
+    * This is the case because linkFile is also not supported. Use a ''RemoteDiskStorage'' if you want to have this functionality.
+    */
+  final class FetchDigest[F[_]]()(implicit F: Effect[F]) extends FetchFileDigest[F] {
+    override def apply(path: Uri.Path): F[Digest] =
       F.raiseError(KgError.UnsupportedOperation)
   }
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/FileDigestProjection.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/FileDigestProjection.scala
@@ -1,0 +1,78 @@
+package ch.epfl.bluebrain.nexus.kg.storage
+
+import akka.actor.ActorSystem
+import cats.MonadError
+import cats.effect.{Effect, Timer}
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.admin.client.types.Project
+import ch.epfl.bluebrain.nexus.kg.KgError
+import ch.epfl.bluebrain.nexus.kg.KgError.InternalError
+import ch.epfl.bluebrain.nexus.kg.config.AppConfig
+import ch.epfl.bluebrain.nexus.kg.config.AppConfig._
+import ch.epfl.bluebrain.nexus.kg.instances.kgErrorMonadError
+import ch.epfl.bluebrain.nexus.kg.resources.Rejection._
+import ch.epfl.bluebrain.nexus.kg.resources._
+import ch.epfl.bluebrain.nexus.kg.storage.Storage.StorageOperations.FetchDigest
+import ch.epfl.bluebrain.nexus.sourcing.projections._
+
+import scala.concurrent.duration._
+
+private class FileDigestProjectionMapping[F[_]: FetchDigest](files: Files[F])(implicit F: MonadError[F, KgError]) {
+
+  /**
+    * When an event is received, a file digest is attempted to be calculated if the file does not currently have a digest.
+    *
+    * @param event event to be mapped to a Elastic Search insert query
+    */
+  final def apply(event: Event): F[Option[Resource]] = {
+    implicit val subject = event.subject
+    files.updateDigestIfEmpty(event.id).value.flatMap[Option[Resource]] {
+      case Left(FileDigestNotComputed(_)) =>
+        F.raiseError(InternalError(s"Resource '${event.id.ref.show}' does not have a computed digest."): KgError)
+      case Left(UnexpectedState(_)) =>
+        F.raiseError(InternalError(s"Storage for resource '${event.id.ref.show}' is not still on the cache."): KgError)
+      case Left(_) =>
+        F.pure(None)
+      case Right(resource) =>
+        F.pure(Some(resource))
+    }
+  }
+}
+
+object FileDigestProjection {
+
+  // $COVERAGE-OFF$
+  /**
+    * Starts the projection process to compute the digest of the missing files
+    *
+    * @param files         the files bundle operations
+    * @param project       the project to which the resource belongs
+    */
+  final def start[F[_]: Timer](
+      files: Files[F],
+      project: Project,
+      restartOffset: Boolean
+  )(implicit fetchDigest: FetchDigest[F],
+    P: Projections[F, Event],
+    as: ActorSystem,
+    config: AppConfig,
+    F: Effect[F]): StreamSupervisor[F, ProjectionProgress] = {
+
+    val mapper = new FileDigestProjectionMapping(files)(fetchDigest, kgErrorMonadError)
+
+    val ignoreIndex: List[Resource] => F[Unit] = _ => F.unit
+
+    TagProjection.start(
+      ProjectionConfig
+        .builder[F]
+        .name(s"digest-computation-${project.uuid}")
+        .tag(s"project=${project.uuid}")
+        .plugin(config.persistence.queryJournalPlugin)
+        .retry[KgError](config.storage.digestRetry.retryStrategy)(kgErrorMonadError)
+        .batch(1, 1 millis)
+        .restart(restartOffset)
+        .mapping(mapper.apply)
+        .index(ignoreIndex)
+        .build)
+  }
+}

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperations.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperations.scala
@@ -152,4 +152,14 @@ object S3StorageOperations {
         .to[F]
     }
   }
+
+  /**
+    * [[FetchFileDigest]] implementation for [[S3Storage]] that always throws an error since this operation is not supported.
+    * This is the case because linkFile is already always computing the digest.
+    * We might want to change this behaviour in the future, but we don't have a use case for it no.
+    */
+  final class FetchDigest[F[_]]()(implicit F: Effect[F]) extends FetchFileDigest[F] {
+    override def apply(path: Uri.Path): F[Digest] =
+      F.raiseError(KgError.UnsupportedOperation)
+  }
 }

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
@@ -32,7 +32,8 @@ class AppConfigSpec extends WordSpecLike with Matchers with OptionValues with Te
         RemoteDiskStorageConfig("http://localhost:8084/v1", None, "SHA-256", read, write, true, 10737418240L),
         S3StorageConfig("SHA-256", read, write, true, 10737418240L),
         "changeme",
-        "salt"
+        "salt",
+        RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
       )
       appConfig.iam shouldEqual IamConfig(url"http://localhost:8080/v1".value,
                                           url"http://localhost:8080/v1".value,

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
@@ -33,13 +33,13 @@ class AppConfigSpec extends WordSpecLike with Matchers with OptionValues with Te
         S3StorageConfig("SHA-256", read, write, true, 10737418240L),
         "changeme",
         "salt",
-        RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
+        RetryStrategyConfig("linear", 300 millis, 10 seconds, 10000, 0.2, 1 second)
       )
       appConfig.iam shouldEqual IamConfig(url"http://localhost:8080/v1".value,
                                           url"http://localhost:8080/v1".value,
                                           None,
                                           1 second)
-      val retryIndex = RetryStrategyConfig("exponential", 100 millis, 10 minutes, 7, 0.2, 500 millis)
+      val retryIndex = RetryStrategyConfig("exponential", 100 millis, 3 minutes, 30, 0.2, 500 millis)
       val retryQuery = RetryStrategyConfig("exponential", 100 millis, 1 minute, 4, 0.2, 500 millis)
       appConfig.sparql shouldEqual SparqlConfig("http://localhost:9999/bigdata",
                                                 "kg",

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectivesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectivesSpec.scala
@@ -33,6 +33,7 @@ import ch.epfl.bluebrain.nexus.kg.storage.StorageEncoder._
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import ch.epfl.bluebrain.nexus.rdf.syntax._
 import ch.epfl.bluebrain.nexus.rdf.instances._
+import ch.epfl.bluebrain.nexus.sourcing.akka.SourcingConfig.RetryStrategyConfig
 import io.circe.Json
 import io.circe.generic.auto._
 import monix.eval.Task
@@ -40,6 +41,8 @@ import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, EitherValues, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
 
 class QueryDirectivesSpec
     extends WordSpecLike
@@ -64,7 +67,8 @@ class QueryDirectivesSpec
         RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
         S3StorageConfig("MD5", read, write, true, 1024L),
         "password",
-        "salt"
+        "salt",
+        RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
       )
 
     implicit def paginationMarshaller(implicit m1: ToEntityMarshaller[FromPagination],

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/DigestSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/DigestSpec.scala
@@ -1,0 +1,74 @@
+package ch.epfl.bluebrain.nexus.kg.resources
+
+import ch.epfl.bluebrain.nexus.commons.test.Randomness
+import ch.epfl.bluebrain.nexus.kg.TestHelper
+import ch.epfl.bluebrain.nexus.kg.config.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.kg.resources.Rejection.InvalidResourceFormat
+import ch.epfl.bluebrain.nexus.kg.resources.file.File.Digest
+import ch.epfl.bluebrain.nexus.rdf.syntax._
+import io.circe.Json
+import io.circe.syntax._
+import org.scalatest.{EitherValues, Matchers, WordSpec}
+
+class DigestSpec extends WordSpec with Matchers with TestHelper with Randomness with EitherValues {
+
+  private abstract class Ctx {
+    val id = Id(ProjectRef(genUUID), genIri)
+    def jsonDigest(digest: Digest, tpe: String = nxv.UpdateDigest.prefix): Json =
+      Json.obj("@id"       -> id.value.asString.asJson,
+               "@type"     -> tpe.asJson,
+               "value"     -> digest.value.asJson,
+               "algorithm" -> digest.algorithm.asJson)
+
+  }
+
+  "A Digest" should {
+
+    "be converted to digest case class correctly" in new Ctx {
+      val digest = Digest("SHA-256", genString())
+      Digest(id, jsonDigest(digest)).right.value shouldEqual digest
+    }
+
+    "reject when algorithm is missing" in new Ctx {
+      val digest = Digest("SHA-256", genString())
+      Digest(id, jsonDigest(digest).removeKeys("algorithm")).left.value shouldEqual
+        InvalidResourceFormat(id.ref, "'algorithm' field does not have the right format.")
+    }
+
+    "reject when value is missing" in new Ctx {
+      val digest = Digest("SHA-256", genString())
+      Digest(id, jsonDigest(digest).removeKeys("value")).left.value shouldEqual
+        InvalidResourceFormat(id.ref, "'value' field does not have the right format.")
+    }
+
+    "reject when value is empty" in new Ctx {
+      val digest = Digest("SHA-256", "")
+      Digest(id, jsonDigest(digest)).left.value shouldEqual
+        InvalidResourceFormat(id.ref, "'value' field does not have the right format.")
+    }
+
+    "reject when algorithm is empty" in new Ctx {
+      val digest = Digest("", genString())
+      Digest(id, jsonDigest(digest)).left.value shouldEqual
+        InvalidResourceFormat(id.ref, "'algorithm' field does not have the right format.")
+    }
+
+    "reject when algorithm is invalid" in new Ctx {
+      val digest = Digest(genString(), genString())
+      Digest(id, jsonDigest(digest)).left.value shouldEqual
+        InvalidResourceFormat(id.ref, "'algorithm' field does not have the right format.")
+    }
+
+    "reject when @type is missing" in new Ctx {
+      val digest = Digest(genString(), genString())
+      Digest(id, jsonDigest(digest).removeKeys("@type")).left.value shouldEqual
+        InvalidResourceFormat(id.ref, "'@type' field does not have the right format.")
+    }
+    "reject when @type is invalid" in new Ctx {
+      val digest = Digest(genString(), genString())
+      Digest(id, jsonDigest(digest, tpe = genString())).left.value shouldEqual
+        InvalidResourceFormat(id.ref, "'@type' field does not have the right format.")
+    }
+  }
+
+}

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/DigestSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/DigestSpec.scala
@@ -66,7 +66,7 @@ class DigestSpec extends WordSpec with Matchers with TestHelper with Randomness 
     }
     "reject when @type is invalid" in new Ctx {
       val digest = Digest(genString(), genString())
-      Digest(id, jsonDigest(digest, tpe = genString())).left.value shouldEqual
+      Digest(id, jsonDigest(digest, tpe = genIri.asString)).left.value shouldEqual
         InvalidResourceFormat(id.ref, "'@type' field does not have the right format.")
     }
   }

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/FilesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/FilesSpec.scala
@@ -172,7 +172,7 @@ class FilesSpec
         saveFile(resId, desc, source) shouldReturn IO.pure(attributes)
 
         files.create(resId, storage, desc, source).value.accepted shouldBe a[Resource]
-        files.updateDigestIfEmpty(resId).value.rejected[ResourceAlreadyExists]
+        files.updateDigestIfEmpty(resId).value.rejected[FileDigestAlreadyExists]
       }
 
       "prevent updating a file digest when file does not exist" in new Base {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/serializers/EventSerializerSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/serializers/EventSerializerSpec.scala
@@ -21,10 +21,13 @@ import ch.epfl.bluebrain.nexus.kg.resources.{Id, OrganizationRef, ProjectRef, Re
 import ch.epfl.bluebrain.nexus.kg.serializers.Serializer.EventSerializer
 import ch.epfl.bluebrain.nexus.kg.storage.Storage.DiskStorage
 import ch.epfl.bluebrain.nexus.rdf.syntax.node.unsafe._
+import ch.epfl.bluebrain.nexus.sourcing.akka.SourcingConfig.RetryStrategyConfig
 import io.circe.Json
 import io.circe.parser._
 import org.scalatest._
 import shapeless.Typeable
+
+import scala.concurrent.duration._
 
 class EventSerializerSpec
     extends WordSpecLike
@@ -44,7 +47,8 @@ class EventSerializerSpec
       RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
       S3StorageConfig("MD5", read, write, true, 1024L),
       "password",
-      "salt"
+      "salt",
+      RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
     )
   private case class Other(str: String)
 

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperationsSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperationsSpec.scala
@@ -11,8 +11,11 @@ import ch.epfl.bluebrain.nexus.kg.config.AppConfig._
 import ch.epfl.bluebrain.nexus.kg.resources.file.File.FileDescription
 import ch.epfl.bluebrain.nexus.kg.resources.{Id, ProjectRef}
 import ch.epfl.bluebrain.nexus.kg.{KgError, TestHelper}
+import ch.epfl.bluebrain.nexus.sourcing.akka.SourcingConfig.RetryStrategyConfig
 import org.mockito.IdiomaticMockito
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
 
 class DiskStorageOperationsSpec
     extends ActorSystemFixture("DiskStorageOperationsSpec")
@@ -29,7 +32,8 @@ class DiskStorageOperationsSpec
     RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
     S3StorageConfig("MD5", read, write, true, 1024L),
     "password",
-    "salt"
+    "salt",
+    RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
   )
 
   private val project  = ProjectRef(genUUID)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperationsSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperationsSpec.scala
@@ -15,11 +15,14 @@ import ch.epfl.bluebrain.nexus.kg.resources.file.File.{Digest, FileAttributes, F
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
 import ch.epfl.bluebrain.nexus.kg.resources.{Id, ProjectRef}
 import ch.epfl.bluebrain.nexus.kg.storage.Storage.RemoteDiskStorage
+import ch.epfl.bluebrain.nexus.sourcing.akka.SourcingConfig.RetryStrategyConfig
 import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import ch.epfl.bluebrain.nexus.storage.client.types.FileAttributes.{Digest => StorageDigest}
 import ch.epfl.bluebrain.nexus.storage.client.types.{FileAttributes => StorageFileAttributes}
 import org.mockito.{IdiomaticMockito, Mockito}
 import org.scalatest._
+
+import scala.concurrent.duration._
 
 class RemoteDiskStorageOperationsSpec
     extends ActorSystemFixture("RemoteDiskStorageOperationsSpec")
@@ -40,7 +43,8 @@ class RemoteDiskStorageOperationsSpec
     RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
     S3StorageConfig("MD5", read, write, true, 1024L),
     "password",
-    "salt"
+    "salt",
+    RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
   )
 
   sealed trait Ctx {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperationsSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperationsSpec.scala
@@ -4,10 +4,11 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Paths
 import java.util.UUID
 
+import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.Uri
 import akka.stream.alpakka.s3
-import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.scaladsl.{FileIO, Sink}
+import akka.stream.{ActorMaterializer, Materializer}
 import cats.effect.IO
 import ch.epfl.bluebrain.nexus.commons.test.io.IOValues
 import ch.epfl.bluebrain.nexus.commons.test.{ActorSystemFixture, Randomness, Resources}
@@ -19,15 +20,16 @@ import ch.epfl.bluebrain.nexus.kg.resources.file.File.{Digest, FileAttributes, F
 import ch.epfl.bluebrain.nexus.kg.resources.{Id, ProjectRef}
 import ch.epfl.bluebrain.nexus.kg.storage.Storage.{S3Credentials, S3Settings, S3Storage}
 import ch.epfl.bluebrain.nexus.rdf.syntax._
+import ch.epfl.bluebrain.nexus.sourcing.akka.SourcingConfig.RetryStrategyConfig
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, AnonymousAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import akka.http.scaladsl.model.ContentTypes._
 import io.findify.s3mock.S3Mock
 import org.scalatest._
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.concurrent.duration._
 
 class S3StorageOperationsSpec
     extends ActorSystemFixture("S3StorageOperationsSpec")
@@ -57,7 +59,8 @@ class S3StorageOperationsSpec
     RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
     S3StorageConfig("MD5", readS3, writeS3, true, 1024L),
     "password",
-    "salt"
+    "salt",
+    RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
   )
 
   private val keys  = Set("http.proxyHost", "http.proxyPort", "https.proxyHost", "https.proxyPort", "http.nonProxyHosts")

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageSpec.scala
@@ -17,8 +17,11 @@ import ch.epfl.bluebrain.nexus.kg.resources.{Id, ProjectRef}
 import ch.epfl.bluebrain.nexus.kg.storage.Storage._
 import ch.epfl.bluebrain.nexus.kg.storage.StorageEncoder._
 import ch.epfl.bluebrain.nexus.rdf.syntax._
+import ch.epfl.bluebrain.nexus.sourcing.akka.SourcingConfig.RetryStrategyConfig
 import io.circe.Json
 import org.scalatest.{Inspectors, Matchers, OptionValues, WordSpecLike}
+
+import scala.concurrent.duration._
 
 class StorageSpec
     extends WordSpecLike
@@ -39,7 +42,8 @@ class StorageSpec
       RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 2000L),
       S3StorageConfig("MD5", readS3, writeS3, true, 3000L),
       "password",
-      "salt"
+      "salt",
+      RetryStrategyConfig("linear", 300 millis, 5 minutes, 100, 0.2, 1 second)
     )
   "A Storage" when {
     val iri        = url"http://example.com/id".value


### PR DESCRIPTION
- Added a `UpdateFileDigest` command
- Added a `FileDigestUpdated` event
- Added an async process which reads events by tag (project={projectUuid}) and checks which files require a digest update. For those, it asks the StorageOperations to fetch the digest. There is a retry mechanisms in place to attempt to fetch the digest if the previously fetched digest was empty
- Added routes to manually apply a digest update: PATCH `/v1/files/{org}/{proj}/{file}`