### PR TITLE
Prevent from creating unnecessary indices/namespaces

### DIFF
--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/Indexing.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/Indexing.scala
@@ -98,7 +98,7 @@ private class Indexing(storages: Storages[Task],
     implicit val acls: AccessControlLists = AccessControlLists.empty
     val view: View                        = ElasticSearchView.default(project.ref)
     asJson(view).flatMap { json =>
-      val created = views.create(Id(project.ref, view.id), json).value
+      val created = views.create(Id(project.ref, view.id), json, extractUuid = true).value
       created.mapRetry(
         createdOrExists,
         InternalError(s"Couldn't create default ElasticSearch view for project '${project.ref}'"): KgError)
@@ -109,7 +109,7 @@ private class Indexing(storages: Storages[Task],
     implicit val acls: AccessControlLists = AccessControlLists.empty
     val view: View                        = SparqlView.default(project.ref)
     asJson(view).flatMap { json =>
-      val created = views.create(Id(project.ref, view.id), json).value
+      val created = views.create(Id(project.ref, view.id), json, extractUuid = true).value
       created.mapRetry(createdOrExists,
                        InternalError(s"Couldn't create default Sparql view for project '${project.ref}'"): KgError)
     }


### PR DESCRIPTION
Fixes:
- Unnecessary indices creation when the projections table got removed. This was caused by the default UUIDs being ignored. Now the fixed UUID is applied.
- Unnecessary Elasticsearch indices creation on views update. This was caused by the ElaticSearch mappings validity check using a wrong UUID