### PR TITLE
Added support to remove organizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ scalafmt: {
  */
 
 // Dependency versions
-val adminVersion                = "35e480cf"
+val adminVersion                = "64496380"
 val commonsVersion              = "0.17.5"
 val storageVersion              = "c6f845b8"
 val sourcingVersion             = "0.16.5"


### PR DESCRIPTION
- Added support for parameter: `--org {org}` (multiple times)
- Added support for parameter: `--select-size` to specify the number of rows returned from a select statement
- Removed `ALLOW FILTERING` queries. This prevents from query timeouts but it needs to traverse all the rows.
- Write to a temporary file the queries to be removed and execute the removal in a subsequent source. This is necessary to avoid messing up the selec pagination.
