### PR TITLE
Added version endpoint and bumped dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,9 @@ scalafmt: {
  */
 
 // Dependency versions
-val adminVersion                = "13fa9121"
-val commonsVersion              = "0.17.11"
-val storageVersion              = "5c77a3a7"
+val adminVersion                = "51b9575d"
+val commonsVersion              = "0.17.14"
+val storageVersion              = "d7142488"
 val sourcingVersion             = "0.16.6"
 val akkaVersion                 = "2.5.25"
 val akkaCorsVersion             = "0.4.1"

--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -88,15 +88,32 @@ akka {
       "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$ProjectChanges"       = kryo
       "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$FetchProgress"        = kryo
 
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectAttributesCoordinatorActor$Msg$Start"            = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectAttributesCoordinatorActor$Msg$Stop"             = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectAttributesCoordinatorActor$Msg$FetchProgress"    = kryo
+
+      "ch.epfl.bluebrain.nexus.kg.archives.ArchiveCache$Request$Read"    = kryo
+      "ch.epfl.bluebrain.nexus.kg.archives.ArchiveCache$Request$Write"   = kryo
+      "ch.epfl.bluebrain.nexus.kg.archives.ArchiveCache$Stop$"           = kryo
+      "ch.epfl.bluebrain.nexus.kg.archives.ArchiveCache$ReadResponse"    = kryo
+      "ch.epfl.bluebrain.nexus.kg.archives.ArchiveCache$WriteResponse"   = kryo
+
       # key value store types
+      "ch.epfl.bluebrain.nexus.kg.archives.Archive"                        = kryo
+      "ch.epfl.bluebrain.nexus.kg.archives.Archive$ResourceDescription"    = kryo
+      "ch.epfl.bluebrain.nexus.kg.archives.Archive$File"                   = kryo
+      "ch.epfl.bluebrain.nexus.kg.archives.Archive$Resource"               = kryo
       "ch.epfl.bluebrain.nexus.kg.indexing.View"                           = kryo
       "ch.epfl.bluebrain.nexus.kg.resolve.Resolver"                        = kryo
       "ch.epfl.bluebrain.nexus.rdf.Iri$AbsoluteIri"                        = kryo
       "ch.epfl.bluebrain.nexus.rdf.Iri$Path"                               = kryo
       "ch.epfl.bluebrain.nexus.iam.client.types.ResourceAccessControlList" = kryo
       "ch.epfl.bluebrain.nexus.admin.client.types.Project"                 = kryo
-      "ch.epfl.bluebrain.nexus.kg.RevisionedValue" = kryo
+      "ch.epfl.bluebrain.nexus.kg.resources.ProjectRef"                    = kryo
+      "ch.epfl.bluebrain.nexus.kg.resources.Id"                            = kryo
+      "ch.epfl.bluebrain.nexus.kg.RevisionedValue"                         = kryo
       "java.util.UUID"                                                     = kryo
+      "java.time.Instant"                                                  = kryo
 
       # generic values sent across the wire
       "scala.runtime.BoxedUnit"        = kryo

--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -77,8 +77,10 @@ app {
     }
     # Remote disk storage configuration
     remote-disk {
-      default-endpoint = "http://localhost:8084/v1"
+      default-endpoint = "http://localhost:8084"
       default-endpoint = ${?REMOTE_DISK_DEFAULT_ENDPOINT}
+      default-endpoint-prefix = "v1"
+      default-endpoint-prefix = ${?REMOTE_DISK_DEFAULT_ENDPOINT_PREFIX}
       default-credentials = ${?REMOTE_DISK_DEFAULT_CREDENTIALS}
       digest-algorithm = "SHA-256"
       digest-algorithm = ${?DIGEST_ALGORITHM}
@@ -142,20 +144,27 @@ app {
   # Nexus-admin settings
   admin {
     # The public iri to the admin service
-    public-iri = "http://localhost:8080/v1"
+    public-iri = "http://localhost:8080"
     public-iri = ${?ADMIN_PUBLIC_IRI}
     # The internal iri to the admin service
-    internal-iri = "http://localhost:8080/v1"
+    internal-iri = "http://localhost:8080"
     internal-iri = ${?ADMIN_INTERNAL_IRI}
+    # The version prefix
+    prefix = "v1"
+    prefix = ${?ADMIN_PREFIX}
   }
 
   iam {
     # The public iri to the iam service
-    public-iri = "http://localhost:8080/v1"
+    public-iri = "http://localhost:8080"
     public-iri = ${?IAM_PUBLIC_IRI}
     # The internal iri to the iam service
-    internal-iri = "http://localhost:8080/v1"
+    internal-iri = "http://localhost:8080"
     internal-iri = ${?IAM_INTERNAL_IRI}
+
+    # The version prefix
+    prefix = "v1"
+    prefix = ${?IAM_PREFIX}
 
     # The service account token to execute calls to IAM
     service-account-token = ${?IAM_SA_TOKEN}

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorActor.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorActor.scala
@@ -8,6 +8,7 @@ import akka.cluster.sharding.ShardRegion.{ExtractEntityId, ExtractShardId}
 import akka.cluster.sharding.{ClusterSharding, ClusterShardingSettings, ShardRegion}
 import akka.pattern.pipe
 import akka.persistence.query.{NoOffset, Offset, Sequence, TimeBasedUUID}
+import akka.stream.{ActorMaterializer, Materializer}
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.admin.client.types.Project
 import ch.epfl.bluebrain.nexus.commons.cache.KeyValueStoreSubscriber.KeyValueStoreChange._
@@ -307,6 +308,8 @@ object ProjectViewCoordinatorActor {
       as: ActorSystem,
       projections: Projections[Task, Event]
   ): ActorRef = {
+
+    implicit val mt: Materializer = ActorMaterializer()
 
     val props = Props(
       new ProjectViewCoordinatorActor(viewCache) {

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
@@ -210,38 +210,47 @@ object AppConfig {
   /**
     * Remote Disk storage configuration
     *
-    * @param defaultEndpoint    the default endpoint of the current storage
-    * @param defaultCredentials the default credentials for the defaultEnpoint of the current storage
-    * @param readPermission     the default permission required in order to download a file from a disk storage
-    * @param writePermission    the default permission required in order to upload a file to a disk storage
-    * @param showLocation       flag to decide whether or not to show the absolute location of the files in the metadata response
-    * @param maxFileSize        the default maximum allowed file size (in bytes) for uploaded files
+    * @param defaultEndpoint       the default endpoint of the current storage
+    * @param defaultEndpointPrefix the default endpoint prefix
+    * @param defaultCredentials    the default credentials for the defaultEnpoint of the current storage
+    * @param readPermission        the default permission required in order to download a file from a disk storage
+    * @param writePermission       the default permission required in order to upload a file to a disk storage
+    * @param showLocation          flag to decide whether or not to show the absolute location of the files in the metadata response
+    * @param maxFileSize           the default maximum allowed file size (in bytes) for uploaded files
     */
   final case class RemoteDiskStorageConfig(
       defaultEndpoint: Uri,
+      defaultEndpointPrefix: String,
       defaultCredentials: Option[AuthToken],
       digestAlgorithm: String,
       readPermission: Permission,
       writePermission: Permission,
       showLocation: Boolean,
       maxFileSize: Long
-  )
+  ) {
+    val endppint: Uri =
+      if (defaultEndpointPrefix.trim.isEmpty) defaultEndpoint
+      else s"$defaultEndpoint/$defaultEndpointPrefix"
+  }
 
   /**
     * IAM config
     *
-    * @param publicIri           base URL for all the identity IDs, including prefix.
-    * @param internalIri         base URL for all the HTTP calls, including prefix.
+    * @param publicIri           base URL for all the identity IDs, excluding prefix
+    * @param internalIri         base URL for all the HTTP calls, excluding prefix
+    * @param prefix              the prefix
     * @param serviceAccountToken the service account token to execute calls to IAM
     * @param sseRetryDelay       delay for retrying after completion on SSE
     */
   final case class IamConfig(
       publicIri: AbsoluteIri,
       internalIri: AbsoluteIri,
+      prefix: String,
       serviceAccountToken: Option[AuthToken],
       sseRetryDelay: FiniteDuration
   ) {
-    val iamClient: IamClientConfig = IamClientConfig(publicIri, internalIri, sseRetryDelay)
+    val iamClient: IamClientConfig      = IamClientConfig(publicIri, internalIri, prefix, sseRetryDelay)
+    lazy val basePublicIri: AbsoluteIri = iamClient.basePublicIri
   }
 
   /**

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/SparqlIndexer.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/SparqlIndexer.scala
@@ -4,6 +4,7 @@ import java.util.Properties
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.http.scaladsl.model.Uri
+import akka.stream.{ActorMaterializer, Materializer}
 import cats.Monad
 import cats.effect.{Effect, Timer}
 import cats.implicits._
@@ -84,9 +85,9 @@ object SparqlIndexer {
       config: AppConfig
   ): StreamSupervisor[F, ProjectionProgress] = {
 
-    val sparqlErrorMonadError             = ch.epfl.bluebrain.nexus.kg.instances.sparqlErrorMonadError
-    implicit val indexing: IndexingConfig = config.sparql.indexing
-
+    val sparqlErrorMonadError               = ch.epfl.bluebrain.nexus.kg.instances.sparqlErrorMonadError
+    implicit val indexing: IndexingConfig   = config.sparql.indexing
+    implicit val materializer: Materializer = ActorMaterializer()
     val properties: Map[String, String] = {
       val props = new Properties()
       props.load(getClass.getResourceAsStream("/blazegraph/index.properties"))

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/ResourceF.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/ResourceF.scala
@@ -116,7 +116,7 @@ final case class ResourceF[A](
     }
 
     val fileTriples = file.map(triplesFor).getOrElse(Set.empty)
-    val projectUri  = config.admin.publicIri + "projects" / project.organizationLabel / project.label
+    val projectUri  = config.admin.publicIri + config.admin.prefix / "projects" / project.organizationLabel / project.label
     val self        = AccessId(id.value, schema.iri, expanded = options.expandedLinks)
     fileTriples + (
       (node, nxv.rev, rev),

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Clients.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Clients.scala
@@ -8,28 +8,31 @@ import ch.epfl.bluebrain.nexus.commons.http.HttpClient.UntypedHttpClient
 import ch.epfl.bluebrain.nexus.commons.sparql.client.BlazegraphClient
 import ch.epfl.bluebrain.nexus.commons.search.QueryResults
 import ch.epfl.bluebrain.nexus.iam.client.IamClient
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import io.circe.Json
 import monix.eval.Task
 
 /**
   * Wraps the different clients
   *
-  * @param sparql        the sparql indexer client
-  * @param elasticSearch the ElasticSearch indexer client
-  * @param adminClient   the implicitly available admin client
-  * @param iamClient     the implicitly available iam client
-  * @param httpClient    the implicitly available [[UntypedHttpClient]]
-  * @param uclJson       the implicitly available [[HttpClient]] with a JSON unmarshaller
-  * @param mt            the implicitly available [[ActorMaterializer]]
+  * @param sparql               the sparql indexer client
+  * @param elasticSearch        the ElasticSearch indexer client
+  * @param admin                the implicitly available admin client
+  * @param iam                  the implicitly available iam client
+  * @param defaultRemoteStorage the implicitly available storage client
+  * @param http                 the implicitly available [[UntypedHttpClient]]
+  * @param uclJson              the implicitly available [[HttpClient]] with a JSON unmarshaller
+  * @param mt                   the implicitly available [[ActorMaterializer]]
   * @tparam F the monadic effect type
   */
 final case class Clients[F[_]]()(
     implicit val sparql: BlazegraphClient[F],
     val elasticSearch: ElasticSearchClient[F],
-    val adminClient: AdminClient[F],
-    val iamClient: IamClient[F],
+    val admin: AdminClient[F],
+    val iam: IamClient[F],
+    val defaultRemoteStorage: StorageClient[F],
     val rsSearch: HttpClient[F, QueryResults[Json]],
-    val httpClient: UntypedHttpClient[Task],
+    val http: UntypedHttpClient[Task],
     val uclJson: HttpClient[Task, Json],
     val mt: ActorMaterializer
 )

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Routes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Routes.scala
@@ -196,15 +196,8 @@ object Routes {
     implicit val projectCache: ProjectCache[Task] = cache.project
     implicit val viewCache: ViewCache[Task]       = cache.view
 
-    val healthStatusGroup = HealthStatusGroup(
-      new CassandraHealthStatus(),
-      new ClusterHealthStatus(Cluster(system)),
-      new IamHealthStatus(clients.iamClient),
-      new AdminHealthStatus(clients.adminClient),
-      new ElasticSearchHealthStatus(clients.elasticSearch),
-      new SparqlHealthStatus(clients.sparql)
-    )
-    val appInfoRoutes = AppInfoRoutes(config.description, healthStatusGroup).routes
+    val healthStatusGroup = HealthStatusGroup(new CassandraHealthStatus(), new ClusterHealthStatus(Cluster(system)))
+    val appInfoRoutes     = AppInfoRoutes(config.description, healthStatusGroup).routes
 
     def list(implicit acls: AccessControlLists, caller: Caller, project: Project): Route =
       (get & paginated & searchParams & pathEndOrSingleSlash) { (pagination, params) =>

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Routes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Routes.scala
@@ -32,8 +32,8 @@ import ch.epfl.bluebrain.nexus.kg.directives.QueryDirectives._
 import ch.epfl.bluebrain.nexus.kg.marshallers.instances._
 import ch.epfl.bluebrain.nexus.kg.resources._
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
-import ch.epfl.bluebrain.nexus.kg.routes.AppInfoRoutes.HealthStatusGroup
-import ch.epfl.bluebrain.nexus.kg.routes.HealthStatus._
+import ch.epfl.bluebrain.nexus.kg.routes.AppInfoRoutes.StatusGroup
+import ch.epfl.bluebrain.nexus.kg.routes.Status._
 import ch.epfl.bluebrain.nexus.kg.search.QueryResultEncoder._
 import ch.epfl.bluebrain.nexus.storage.client.StorageClientError
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives.{cors, corsRejectionHandler}
@@ -196,7 +196,7 @@ object Routes {
     implicit val projectCache: ProjectCache[Task] = cache.project
     implicit val viewCache: ViewCache[Task]       = cache.view
 
-    val healthStatusGroup = HealthStatusGroup(new CassandraHealthStatus(), new ClusterHealthStatus(Cluster(system)))
+    val healthStatusGroup = StatusGroup(new CassandraStatus(), new ClusterStatus(Cluster(system)))
     val appInfoRoutes     = AppInfoRoutes(config.description, healthStatusGroup).routes
 
     def list(implicit acls: AccessControlLists, caller: Caller, project: Project): Route =

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Status.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Status.scala
@@ -11,7 +11,7 @@ import monix.eval.Task
 
 import scala.concurrent.Future
 
-sealed trait HealthStatus {
+sealed trait Status {
 
   /**
     * Checks the connectivity.
@@ -22,9 +22,9 @@ sealed trait HealthStatus {
   def check: Task[Boolean]
 }
 
-object HealthStatus {
+object Status {
 
-  class CassandraHealthStatus(implicit as: ActorSystem, persistence: PersistenceConfig) extends HealthStatus {
+  class CassandraStatus(implicit as: ActorSystem, persistence: PersistenceConfig) extends Status {
     implicit val ec     = as.dispatcher
     private val log     = Logging(as, "CassandraHeathCheck")
     private val config  = new CassandraPluginConfig(as, as.settings.config.getConfig(persistence.journalPlugin))
@@ -40,7 +40,7 @@ object HealthStatus {
       })
   }
 
-  class ClusterHealthStatus(cluster: Cluster) extends HealthStatus {
+  class ClusterStatus(cluster: Cluster) extends Status {
     override def check: Task[Boolean] =
       Task.pure(
         !cluster.isTerminated &&

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperations.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperations.scala
@@ -11,7 +11,6 @@ import ch.epfl.bluebrain.nexus.kg.storage.Storage._
 import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import ch.epfl.bluebrain.nexus.storage.client.types.FileAttributes.{Digest => StorageDigest}
 import ch.epfl.bluebrain.nexus.storage.client.types.{FileAttributes => StorageFileAttributes}
-import com.github.ghik.silencer.silent
 
 object RemoteDiskStorageOperations {
 
@@ -90,8 +89,7 @@ object RemoteDiskStorageOperations {
     * @param storage the [[RemoteDiskStorage]]
     * @param client  the remote storage client
     */
-  @silent
-  final class FetchAttributes[F[_]: Effect](storage: RemoteDiskStorage, client: StorageClient[F])
+  final class FetchAttributes[F[_]](storage: RemoteDiskStorage, client: StorageClient[F])
       extends FetchFileAttributes[F] {
     implicit val cred = storage.credentials.map(AuthToken)
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/Storage.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/Storage.scala
@@ -389,7 +389,7 @@ object Storage {
     // format: off
     for {
       default       <- c.downField(nxv.default).focus.as[Boolean].onError(res.id.ref, nxv.default.prefix)
-      endpoint      <- c.downField(nxv.endpoint).focus.as[Uri].orElse(config.remoteDisk.defaultEndpoint).onError(res.id.ref, nxv.endpoint.prefix)
+      endpoint      <- c.downField(nxv.endpoint).focus.as[Uri].orElse(config.remoteDisk.endppint).onError(res.id.ref, nxv.endpoint.prefix)
       credentials   <- if(endpoint == config.remoteDisk.defaultEndpoint) c.downField(nxv.credentials).focus.asOption[String].map(_ orElse config.remoteDisk.defaultCredentials.map(_.value)).onError(res.id.ref, nxv.credentials.prefix)
                        else c.downField(nxv.credentials).focus.asOption[String].onError(res.id.ref, nxv.credentials.prefix)
       folder        <- c.downField(nxv.folder).focus.as[String].onError(res.id.ref, nxv.folder.prefix)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/cache/AclCacheSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/cache/AclCacheSpec.scala
@@ -30,7 +30,7 @@ class AclCacheSpec
 
   private val client: IamClient[Task] = mock[IamClient[Task]]
   private implicit val iamConfig: IamConfig =
-    IamConfig(url"http://base.com".value, url"http://base.com".value, None, 1 second)
+    IamConfig(url"http://base.com".value, url"http://base.com".value, "v1", None, 1 second)
   private implicit val appConfig = Settings(system).appConfig.copy(iam = iamConfig)
 
   override val write = Permission.unsafe("resources/write")

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfigSpec.scala
@@ -31,15 +31,16 @@ class AppConfigSpec extends WordSpecLike with Matchers with OptionValues with Te
       )
       appConfig.storage shouldEqual StorageConfig(
         DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false, 10737418240L),
-        RemoteDiskStorageConfig("http://localhost:8084/v1", None, "SHA-256", read, write, true, 10737418240L),
+        RemoteDiskStorageConfig("http://localhost:8084", "v1", None, "SHA-256", read, write, true, 10737418240L),
         S3StorageConfig("SHA-256", read, write, true, 10737418240L),
         "changeme",
         "salt",
         RetryStrategyConfig("linear", 300 millis, 10 seconds, 10000, 0.2, 1 second)
       )
       appConfig.iam shouldEqual IamConfig(
-        url"http://localhost:8080/v1".value,
-        url"http://localhost:8080/v1".value,
+        url"http://localhost:8080".value,
+        url"http://localhost:8080".value,
+        "v1",
         None,
         1 second
       )

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectivesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/directives/QueryDirectivesSpec.scala
@@ -64,7 +64,7 @@ class QueryDirectivesSpec
     implicit val storageConfig =
       StorageConfig(
         DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false, 1024L),
-        RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+        RemoteDiskStorageConfig("http://example.com", "v1", None, "SHA-256", read, write, true, 1024L),
         S3StorageConfig("MD5", read, write, true, 1024L),
         "password",
         "salt",

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/indexing/ElasticSearchIndexerMappingSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/indexing/ElasticSearchIndexerMappingSpec.scala
@@ -141,7 +141,7 @@ class ElasticSearchIndexerMappingSpec
             "_original_source" -> Json.fromString(json.noSpaces),
             "_constrainedBy"   -> Json.fromString(schema.iri.show),
             "_createdAt"       -> Json.fromString(instantString),
-            "_createdBy"       -> Json.fromString((appConfig.iam.publicIri + "anonymous").toString()),
+            "_createdBy"       -> Json.fromString((appConfig.iam.basePublicIri + "anonymous").toString()),
             "_deprecated"      -> Json.fromBoolean(false),
             "_rev"             -> Json.fromLong(2L),
             "_self"            -> Json.fromString(s"http://127.0.0.1:8080/v1/resources/bbp/core/$exSchema/$exResource"),
@@ -153,7 +153,7 @@ class ElasticSearchIndexerMappingSpec
             ),
             "_project"   -> Json.fromString("http://localhost:8080/v1/projects/bbp/core"),
             "_updatedAt" -> Json.fromString(instantString),
-            "_updatedBy" -> Json.fromString((appConfig.iam.publicIri + "anonymous").toString())
+            "_updatedBy" -> Json.fromString((appConfig.iam.basePublicIri + "anonymous").toString())
           )
         mapper(ev).some shouldEqual res.id -> BulkOp.Index(index, id.value.asString, elasticSearchJson)
       }
@@ -217,7 +217,7 @@ class ElasticSearchIndexerMappingSpec
             "_original_source" -> Json.fromString(json.noSpaces),
             "_constrainedBy"   -> Json.fromString(nxv.Resource.value.show),
             "_createdAt"       -> Json.fromString(instantString),
-            "_createdBy"       -> Json.fromString((appConfig.iam.publicIri + "anonymous").toString()),
+            "_createdBy"       -> Json.fromString((appConfig.iam.basePublicIri + "anonymous").toString()),
             "_deprecated"      -> Json.fromBoolean(true),
             "_self"            -> Json.fromString(s"http://127.0.0.1:8080/v1/resources/bbp/core/nxv:Resource/$exResource"),
             "_incoming" -> Json.fromString(
@@ -229,7 +229,7 @@ class ElasticSearchIndexerMappingSpec
             "_project"   -> Json.fromString("http://localhost:8080/v1/projects/bbp/core"),
             "_rev"       -> Json.fromLong(2L),
             "_updatedAt" -> Json.fromString(instantString),
-            "_updatedBy" -> Json.fromString((appConfig.iam.publicIri + "anonymous").toString())
+            "_updatedBy" -> Json.fromString((appConfig.iam.basePublicIri + "anonymous").toString())
           )
         mapper(ev.copy(schema = Ref(nxv.Resource.value))).some shouldEqual
           res.id -> BulkOp.Index(index, id.value.asString, elasticSearchJson)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/resolve/ResolverSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/resolve/ResolverSpec.scala
@@ -42,7 +42,7 @@ class ResolverSpec
   private implicit val projectCache = mock[ProjectCache[CId]]
 
   private implicit val iamClientConfig =
-    IamClientConfig(url"http://example.com/iam/".value, url"http://example.com/iam/".value, 1 second)
+    IamClientConfig(url"http://example.com".value, url"http://example.com".value, "iam", 1 second)
 
   before {
     Mockito.reset(projectCache)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/ResourceFSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/resources/ResourceFSpec.scala
@@ -39,8 +39,8 @@ class ResourceFSpec
     implicit val clock: Clock = Clock.fixed(Instant.ofEpochSecond(3600), ZoneId.systemDefault())
 
     val identity: Identity = User("dmontero", "someRealm")
-    val userIri            = Iri.absolute(s"${appConfig.iam.publicIri.asUri}/realms/someRealm/users/dmontero").right.value
-    val anonIri            = Iri.absolute(s"${appConfig.iam.publicIri.asUri}/anonymous").right.value
+    val userIri            = Iri.absolute(s"${appConfig.iam.basePublicIri.asUri}/realms/someRealm/users/dmontero").right.value
+    val anonIri            = Iri.absolute(s"${appConfig.iam.basePublicIri.asUri}/anonymous").right.value
 
     val projectRef = ProjectRef(genUUID)
     val id         = Iri.absolute(s"http://example.com/${projectRef.id}").right.value

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutesSpec.scala
@@ -2,50 +2,55 @@ package ch.epfl.bluebrain.nexus.kg.routes
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.stream.ActorMaterializer
 import ch.epfl.bluebrain.nexus.admin.client.AdminClient
-import ch.epfl.bluebrain.nexus.admin.client.types.Organization
-import ch.epfl.bluebrain.nexus.commons.es.client.ElasticSearchClient
-import ch.epfl.bluebrain.nexus.commons.sparql.client.BlazegraphClient
+import ch.epfl.bluebrain.nexus.admin.client.types.{ServiceDescription => AdminServiceDescription}
+import ch.epfl.bluebrain.nexus.commons.es.client.{ElasticSearchClient, ServiceDescription => EsServiceDescription}
+import ch.epfl.bluebrain.nexus.commons.http.HttpClient.{untyped, withUnmarshaller}
+import ch.epfl.bluebrain.nexus.commons.search.QueryResults
+import ch.epfl.bluebrain.nexus.commons.sparql.client.{
+  BlazegraphClient,
+  ServiceDescription => BlazegraphServiceDescription
+}
 import ch.epfl.bluebrain.nexus.iam.client.IamClient
-import ch.epfl.bluebrain.nexus.iam.client.types.{AccessControlLists, AuthToken}
+import ch.epfl.bluebrain.nexus.iam.client.types.{ServiceDescription => IamServiceDescription}
 import ch.epfl.bluebrain.nexus.kg.config.Settings
 import ch.epfl.bluebrain.nexus.kg.marshallers.instances._
 import ch.epfl.bluebrain.nexus.kg.routes.AppInfoRoutes.{HealthStatusGroup, ServiceDescription}
 import ch.epfl.bluebrain.nexus.kg.routes.HealthStatus._
-import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
+import ch.epfl.bluebrain.nexus.storage.client.types.{ServiceDescription => StorageServiceDescription}
 import io.circe.Json
 import io.circe.generic.auto._
+import io.circe.syntax._
 import monix.eval.Task
-import org.mockito.Mockito
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.{IdiomaticMockito, Mockito}
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
 
 class AppInfoRoutesSpec
     extends WordSpecLike
     with Matchers
-    with MockitoSugar
+    with IdiomaticMockito
     with BeforeAndAfter
     with ScalatestRouteTest {
 
-  private implicit val appConfig = Settings(system).appConfig
-  private val iam                = mock[IamClient[Task]]
-  private val admin              = mock[AdminClient[Task]]
-  private val elasticSearch      = mock[ElasticSearchClient[Task]]
-  private val sparql             = mock[BlazegraphClient[Task]]
-  private val statusGroup = HealthStatusGroup(
-    mock[CassandraHealthStatus],
-    mock[ClusterHealthStatus],
-    new IamHealthStatus(iam),
-    new AdminHealthStatus(admin),
-    new ElasticSearchHealthStatus(elasticSearch),
-    new SparqlHealthStatus(sparql)
-  )
-  private val routes                            = AppInfoRoutes(appConfig.description, statusGroup).routes
-  private implicit val token: Option[AuthToken] = None
+  private implicit val appConfig     = Settings(system).appConfig
+  private implicit val ec            = system.dispatcher
+  private implicit val mt            = ActorMaterializer()
+  private implicit val utClient      = untyped[Task]
+  private implicit val qrClient      = withUnmarshaller[Task, QueryResults[Json]]
+  private implicit val jsonClient    = withUnmarshaller[Task, Json]
+  private implicit val iam           = mock[IamClient[Task]]
+  private implicit val admin         = mock[AdminClient[Task]]
+  private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
+  private implicit val sparql        = mock[BlazegraphClient[Task]]
+  private implicit val storage       = mock[StorageClient[Task]]
+  private val statusGroup            = HealthStatusGroup(mock[CassandraHealthStatus], mock[ClusterHealthStatus])
+  private implicit val clients       = Clients()
+  private val routes                 = AppInfoRoutes(appConfig.description, statusGroup).routes
 
   before {
-    Mockito.reset(statusGroup.cluster, iam, admin, elasticSearch, sparql, statusGroup.cassandra)
+    Mockito.reset(statusGroup.cluster, iam, admin, elasticSearch, sparql, storage, statusGroup.cassandra)
   }
 
   "An AppInfoRoutes" should {
@@ -60,41 +65,71 @@ class AppInfoRoutesSpec
     }
 
     "return the health status when everything is up" in {
-      when(statusGroup.cassandra.check).thenReturn(Task.pure(true))
-      when(statusGroup.cluster.check).thenReturn(Task.pure(true))
-      when(iam.acls(/)).thenReturn(Task.pure(AccessControlLists()))
-      when(admin.fetchOrganization("test")).thenReturn(Task.pure[Option[Organization]](None))
-      when(elasticSearch.existsIndex("test")).thenReturn(Task.pure(false))
-      when(sparql.namespaceExists).thenReturn(Task.pure(false))
+      statusGroup.cassandra.check shouldReturn Task.pure(true)
+      statusGroup.cluster.check shouldReturn Task.pure(true)
       Get("/health") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         responseAs[Json] shouldEqual Json.obj(
-          "cassandra"     -> Json.fromString("up"),
-          "cluster"       -> Json.fromString("up"),
-          "iam"           -> Json.fromString("up"),
-          "admin"         -> Json.fromString("up"),
-          "elasticSearch" -> Json.fromString("up"),
-          "sparql"        -> Json.fromString("up")
+          "cassandra" -> Json.fromString("up"),
+          "cluster"   -> Json.fromString("up")
         )
       }
     }
 
     "return the health status when everything is down" in {
-      when(statusGroup.cassandra.check).thenReturn(Task.pure(false))
-      when(statusGroup.cluster.check).thenReturn(Task.pure(false))
-      when(iam.acls(/)).thenReturn(Task.raiseError(new RuntimeException()))
-      when(admin.fetchOrganization("test")).thenReturn(Task.raiseError(new RuntimeException()))
-      when(elasticSearch.existsIndex("test")).thenReturn(Task.raiseError(new RuntimeException()))
-      when(sparql.namespaceExists).thenReturn(Task.raiseError(new RuntimeException()))
+      statusGroup.cassandra.check shouldReturn Task.pure(false)
+      statusGroup.cluster.check shouldReturn Task.pure(false)
       Get("/health") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         responseAs[Json] shouldEqual Json.obj(
-          "cassandra"     -> Json.fromString("inaccessible"),
-          "cluster"       -> Json.fromString("inaccessible"),
-          "iam"           -> Json.fromString("inaccessible"),
-          "admin"         -> Json.fromString("inaccessible"),
-          "elasticSearch" -> Json.fromString("inaccessible"),
-          "sparql"        -> Json.fromString("inaccessible")
+          "cassandra" -> Json.fromString("inaccessible"),
+          "cluster"   -> Json.fromString("inaccessible")
+        )
+      }
+    }
+
+    "return the version when everything is up" in {
+      val iamServiceDesc        = IamServiceDescription("iam", "1.1.0")
+      val adminServiceDesc      = AdminServiceDescription("admin", "1.1.1")
+      val storageServiceDesc    = StorageServiceDescription("storage", "1.1.2")
+      val esServiceDesc         = EsServiceDescription("elasticsearch", "1.1.3")
+      val blazegraphServiceDesc = BlazegraphServiceDescription("blazegraph", "1.1.4")
+      iam.serviceDescription shouldReturn Task(iamServiceDesc)
+      admin.serviceDescription shouldReturn Task(adminServiceDesc)
+      storage.serviceDescription shouldReturn Task(storageServiceDesc)
+      elasticSearch.serviceDescription shouldReturn Task(esServiceDesc)
+      sparql.serviceDescription shouldReturn Task(blazegraphServiceDesc)
+      Get("/version") ~> routes ~> check {
+        status shouldEqual StatusCodes.OK
+        responseAs[Json] shouldEqual Json.obj(
+          appConfig.description.name -> appConfig.description.version.asJson,
+          adminServiceDesc.name      -> adminServiceDesc.version.asJson,
+          storageServiceDesc.name    -> storageServiceDesc.version.asJson,
+          iamServiceDesc.name        -> iamServiceDesc.version.asJson,
+          blazegraphServiceDesc.name -> blazegraphServiceDesc.version.asJson,
+          esServiceDesc.name         -> esServiceDesc.version.asJson
+        )
+      }
+    }
+
+    "return the version when everything some services are unreachable" in {
+      val iamServiceDesc   = IamServiceDescription("iam", "1.1.0")
+      val adminServiceDesc = AdminServiceDescription("admin", "1.1.1")
+      val esServiceDesc    = EsServiceDescription("elasticsearch", "1.1.3")
+      iam.serviceDescription shouldReturn Task(iamServiceDesc)
+      admin.serviceDescription shouldReturn Task(adminServiceDesc)
+      storage.serviceDescription shouldReturn Task.raiseError(new RuntimeException())
+      elasticSearch.serviceDescription shouldReturn Task(esServiceDesc)
+      sparql.serviceDescription shouldReturn Task.raiseError(new RuntimeException())
+      Get("/version") ~> routes ~> check {
+        status shouldEqual StatusCodes.OK
+        responseAs[Json] shouldEqual Json.obj(
+          appConfig.description.name -> appConfig.description.version.asJson,
+          adminServiceDesc.name      -> adminServiceDesc.version.asJson,
+          "remoteStorage"            -> "unknown".asJson,
+          iamServiceDesc.name        -> iamServiceDesc.version.asJson,
+          "blazegraph"               -> "unknown".asJson,
+          esServiceDesc.name         -> esServiceDesc.version.asJson
         )
       }
     }

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ArchiveRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ArchiveRoutesSpec.scala
@@ -45,6 +45,7 @@ import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito, Mockito}
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import ch.epfl.bluebrain.nexus.kg.config.Contexts._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 
 import scala.concurrent.duration._
 
@@ -97,6 +98,7 @@ class ArchiveRoutesSpec
   private implicit val sparql        = mock[BlazegraphClient[Task]]
   private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
   private implicit val initializer   = mock[ProjectInitializer[Task]]
+  private implicit val storageClient = mock[StorageClient[Task]]
   private implicit val clients       = Clients()
 
   before {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/FileRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/FileRoutesSpec.scala
@@ -42,6 +42,7 @@ import ch.epfl.bluebrain.nexus.kg.storage.{AkkaSource, Storage}
 import ch.epfl.bluebrain.nexus.rdf.Iri.Path
 import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.syntax._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.Json
 import io.circe.generic.auto._
@@ -102,6 +103,7 @@ class FileRoutesSpec
   private implicit val sparql        = mock[BlazegraphClient[Task]]
   private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
   private implicit val initializer   = mock[ProjectInitializer[Task]]
+  private implicit val storageClient = mock[StorageClient[Task]]
   private implicit val clients       = Clients()
 
   before {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResolverRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResolverRoutesSpec.scala
@@ -36,6 +36,7 @@ import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.Iri.{AbsoluteIri, Path}
 import ch.epfl.bluebrain.nexus.rdf.syntax._
 import ch.epfl.bluebrain.nexus.rdf.instances._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.Json
 import io.circe.generic.auto._
@@ -94,6 +95,7 @@ class ResolverRoutesSpec
   private implicit val jsonClient    = withUnmarshaller[Task, Json]
   private implicit val sparql        = mock[BlazegraphClient[Task]]
   private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
+  private implicit val storageClient = mock[StorageClient[Task]]
   private implicit val clients       = Clients()
 
   private val manageResolver = Set(Permission.unsafe("resources/read"), Permission.unsafe("resolvers/write"))

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ResourceRoutesSpec.scala
@@ -37,6 +37,7 @@ import ch.epfl.bluebrain.nexus.rdf.Iri.Path
 import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.instances._
 import ch.epfl.bluebrain.nexus.rdf.syntax._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.Json
 import io.circe.generic.auto._
@@ -94,6 +95,7 @@ class ResourceRoutesSpec
   private implicit val jsonClient    = withUnmarshaller[Task, Json]
   private implicit val sparql        = mock[BlazegraphClient[Task]]
   private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
+  private implicit val storageClient = mock[StorageClient[Task]]
   private implicit val clients       = Clients()
 
   private val manageResources = Set(Permission.unsafe("resources/read"), Permission.unsafe("resources/write"))

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/RoutesFixtures.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/RoutesFixtures.scala
@@ -84,12 +84,14 @@ trait RoutesFixtures extends TestHelper with Resources {
         "@id"            -> Json.fromString(s"nxv:$genUuid"),
         "_constrainedBy" -> schema.iri.asJson,
         "_createdAt"     -> Json.fromString(Instant.EPOCH.toString),
-        "_createdBy"     -> Json.fromString(s"${config.iam.publicIri.asUri}/realms/${user.realm}/users/${user.subject}"),
-        "_deprecated"    -> Json.fromBoolean(deprecated),
-        "_rev"           -> Json.fromLong(1L),
-        "_project"       -> Json.fromString(s"${config.admin.publicIri.asUri}/projects/$organization/$project"),
-        "_updatedAt"     -> Json.fromString(Instant.EPOCH.toString),
-        "_updatedBy"     -> Json.fromString(s"${config.iam.publicIri.asUri}/realms/${user.realm}/users/${user.subject}")
+        "_createdBy" -> Json
+          .fromString(s"${config.iam.basePublicIri.asUri}/realms/${user.realm}/users/${user.subject}"),
+        "_deprecated" -> Json.fromBoolean(deprecated),
+        "_rev"        -> Json.fromLong(1L),
+        "_project" -> Json
+          .fromString(s"${config.admin.publicIri.asUri}/${config.admin.prefix}/projects/$organization/$project"),
+        "_updatedAt" -> Json.fromString(Instant.EPOCH.toString),
+        "_updatedBy" -> Json.fromString(s"${config.iam.basePublicIri.asUri}/realms/${user.realm}/users/${user.subject}")
       )
       .addContext(resourceCtxUri)
 

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/SchemaRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/SchemaRoutesSpec.scala
@@ -35,6 +35,7 @@ import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.Iri.{AbsoluteIri, Path}
 import ch.epfl.bluebrain.nexus.rdf.instances._
 import ch.epfl.bluebrain.nexus.rdf.syntax._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.Json
 import io.circe.generic.auto._
@@ -92,6 +93,7 @@ class SchemaRoutesSpec
   private implicit val jsonClient    = withUnmarshaller[Task, Json]
   private implicit val sparql        = mock[BlazegraphClient[Task]]
   private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
+  private implicit val storageClient = mock[StorageClient[Task]]
   private implicit val clients       = Clients()
 
   before {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/StorageRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/StorageRoutesSpec.scala
@@ -36,6 +36,7 @@ import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.Iri.{AbsoluteIri, Path}
 import ch.epfl.bluebrain.nexus.rdf.syntax._
 import ch.epfl.bluebrain.nexus.rdf.instances._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.Json
 import io.circe.generic.auto._
@@ -93,6 +94,7 @@ class StorageRoutesSpec
   private implicit val jsonClient    = withUnmarshaller[Task, Json]
   private implicit val sparql        = mock[BlazegraphClient[Task]]
   private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
+  private implicit val storageClient = mock[StorageClient[Task]]
   private implicit val clients       = Clients()
 
   before {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ViewRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/ViewRoutesSpec.scala
@@ -43,6 +43,7 @@ import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.Iri.{AbsoluteIri, Path}
 import ch.epfl.bluebrain.nexus.rdf.syntax._
 import ch.epfl.bluebrain.nexus.rdf.instances._
+import ch.epfl.bluebrain.nexus.storage.client.StorageClient
 import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.Json
 import io.circe.parser.parse
@@ -105,6 +106,7 @@ class ViewRoutesSpec
   private implicit val jsonClient    = withUnmarshaller[Task, Json]
   private implicit val sparql        = mock[BlazegraphClient[Task]]
   private implicit val elasticSearch = mock[ElasticSearchClient[Task]]
+  private implicit val storageClient = mock[StorageClient[Task]]
   private implicit val clients       = Clients()
 
   private val manageResolver =

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/serializers/EventSerializerSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/serializers/EventSerializerSpec.scala
@@ -44,7 +44,7 @@ class EventSerializerSpec
   private implicit val storageConfig =
     StorageConfig(
       DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", read, write, false, 1024L),
-      RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+      RemoteDiskStorageConfig("http://example.com", "v1", None, "SHA-256", read, write, true, 1024L),
       S3StorageConfig("MD5", read, write, true, 1024L),
       "password",
       "salt",

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperationsSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperationsSpec.scala
@@ -32,7 +32,7 @@ class DiskStorageOperationsSpec
 
   private implicit val sc: StorageConfig = StorageConfig(
     DiskStorageConfig(Paths.get("/tmp"), "SHA-256", read, write, false, 1024L),
-    RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 1024L),
+    RemoteDiskStorageConfig("http://example.com", "v1", None, "SHA-256", read, write, true, 1024L),
     S3StorageConfig("MD5", read, write, true, 1024L),
     "password",
     "salt",

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/StorageSpec.scala
@@ -39,7 +39,7 @@ class StorageSpec
   private implicit val storageConfig =
     StorageConfig(
       DiskStorageConfig(Paths.get("/tmp/"), "SHA-256", readDisk, writeDisk, false, 1000L),
-      RemoteDiskStorageConfig("http://example.com", None, "SHA-256", read, write, true, 2000L),
+      RemoteDiskStorageConfig("http://example.com", "v1", None, "SHA-256", read, write, true, 2000L),
       S3StorageConfig("MD5", readS3, writeS3, true, 3000L),
       "password",
       "salt",


### PR DESCRIPTION
### Version endpoint
Request: GET /version
Response:
```json
{
  "admin": "{admin_verson}",
  "blazegraph": "2.1.5",
  "elasticsearch-2": "7.2.0",
  "iam": "{iam_verson}",
  "kg": "{kg_verson}",
  "storage": "{remote_storage_verson}"
}
```

### Status endpoint
Request: GET /status
Response:
```json
{
  "cassandra": "up | inaccessible",
  "cluster": "up | inaccessible"
}
```

### Other changes
- Bumped shacl validator dependencies
- Added kryo serialization to necessary classes