### PR TITLE
Optimized attributes computation digest & added global minor to version endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ scalafmt: {
 
 // Dependency versions
 val adminVersion                = "51b9575d"
-val commonsVersion              = "0.17.15"
+val commonsVersion              = "0.17.19"
 val storageVersion              = "d7142488"
 val sourcingVersion             = "0.16.6"
 val akkaVersion                 = "2.5.25"

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutes.scala
@@ -29,7 +29,7 @@ class AppInfoRoutes(serviceDescription: ServiceDescription, status: StatusGroup)
     implicit clients: Clients[Task]
 ) {
   private implicit val orderedKeys =
-    OrderedKeys(List("global", "kg", "admin", "storage", "iam", "elasticsearch", "blazegraph", ""))
+    OrderedKeys(List("nexus", "kg", "admin", "storage", "iam", "elasticsearch", "blazegraph", ""))
 
   private val regex = "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$".r
 
@@ -50,7 +50,7 @@ class AppInfoRoutes(serviceDescription: ServiceDescription, status: StatusGroup)
           val serviceDescriptions = Task.sequence(
             List(
               Task.pure(serviceDescription),
-              Task.pure(ServiceDescription("global", extractGlobalMinor(serviceDescription.version))),
+              Task.pure(ServiceDescription("nexus", extractGlobalMinor(serviceDescription.version))),
               clients.admin.serviceDescription.map(identity).logError("admin"),
               clients.defaultRemoteStorage.serviceDescription.map(identity).logError("remoteStorage"),
               clients.iam.serviceDescription.map(identity).logError("iam"),

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutes.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.Route
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.admin.client.types.{ServiceDescription => AdminServiceDescription}
 import ch.epfl.bluebrain.nexus.commons.es.client.{ServiceDescription => EsServiceDescription}
+import ch.epfl.bluebrain.nexus.commons.http.JsonLdCirceSupport.OrderedKeys
 import ch.epfl.bluebrain.nexus.commons.sparql.client.{ServiceDescription => BlazegraphServiceDescription}
 import ch.epfl.bluebrain.nexus.iam.client.types.{ServiceDescription => IamServiceDescription}
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig.Description
@@ -27,6 +28,10 @@ import monix.execution.Scheduler.Implicits.global
 class AppInfoRoutes(serviceDescription: ServiceDescription, status: StatusGroup)(
     implicit clients: Clients[Task]
 ) {
+  private implicit val orderedKeys =
+    OrderedKeys(List("global", "kg", "admin", "storage", "iam", "elasticsearch", "blazegraph", ""))
+
+  private val regex = "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$".r
 
   def routes: Route =
     concat(
@@ -45,6 +50,7 @@ class AppInfoRoutes(serviceDescription: ServiceDescription, status: StatusGroup)
           val serviceDescriptions = Task.sequence(
             List(
               Task.pure(serviceDescription),
+              Task.pure(ServiceDescription("global", extractGlobalMinor(serviceDescription.version))),
               clients.admin.serviceDescription.map(identity).logError("admin"),
               clients.defaultRemoteStorage.serviceDescription.map(identity).logError("remoteStorage"),
               clients.iam.serviceDescription.map(identity).logError("iam"),
@@ -56,6 +62,12 @@ class AppInfoRoutes(serviceDescription: ServiceDescription, status: StatusGroup)
         }
       }
     )
+
+  private def extractGlobalMinor(version: String): String =
+    version match {
+      case regex(major, minor, _) => s"$major.$minor"
+      case _                      => version
+    }
 }
 
 object AppInfoRoutes {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutesSpec.scala
@@ -102,7 +102,7 @@ class AppInfoRoutesSpec
       Get("/version") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         responseAs[Json] shouldEqual Json.obj(
-          "global"                   -> appConfig.description.version.asJson,
+          "nexus"                    -> appConfig.description.version.asJson,
           appConfig.description.name -> appConfig.description.version.asJson,
           adminServiceDesc.name      -> adminServiceDesc.version.asJson,
           storageServiceDesc.name    -> storageServiceDesc.version.asJson,
@@ -125,7 +125,7 @@ class AppInfoRoutesSpec
       Get("/version") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         responseAs[Json] shouldEqual Json.obj(
-          "global"                   -> appConfig.description.version.asJson,
+          "nexus"                    -> appConfig.description.version.asJson,
           appConfig.description.name -> appConfig.description.version.asJson,
           adminServiceDesc.name      -> adminServiceDesc.version.asJson,
           "remoteStorage"            -> "unknown".asJson,

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutesSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/AppInfoRoutesSpec.scala
@@ -102,6 +102,7 @@ class AppInfoRoutesSpec
       Get("/version") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         responseAs[Json] shouldEqual Json.obj(
+          "global"                   -> appConfig.description.version.asJson,
           appConfig.description.name -> appConfig.description.version.asJson,
           adminServiceDesc.name      -> adminServiceDesc.version.asJson,
           storageServiceDesc.name    -> storageServiceDesc.version.asJson,
@@ -124,6 +125,7 @@ class AppInfoRoutesSpec
       Get("/version") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         responseAs[Json] shouldEqual Json.obj(
+          "global"                   -> appConfig.description.version.asJson,
           appConfig.description.name -> appConfig.description.version.asJson,
           adminServiceDesc.name      -> adminServiceDesc.version.asJson,
           "remoteStorage"            -> "unknown".asJson,


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/787

Also added `global` field to the result on the `/version` endpoint. It will look like:

```json
{
  "global": "1.2",
  "kg": "1.2.1",
  "admin": "1.2.1",
  "storage": "1.2.1",
  "iam": "1.2.1",
  "blazegraph": "2.1.5",
  "elasticsearch": "7.4.0"
}
```