### PR TITLE
Added progress GET and DELETE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ scalafmt: {
 
 // Dependency versions
 val adminVersion                = "1.2.1+2-5e3ee05f"
-val commonsVersion              = "0.19.0"
+val commonsVersion              = "0.19.1"
 val storageVersion              = "1.2.2+2-f21a8d7c"
 val sourcingVersion             = "0.18.0"
 val akkaVersion                 = "2.6.0"
@@ -45,7 +45,7 @@ val monixVersion                = "3.1.0"
 val pureconfigVersion           = "0.12.1"
 val shapelessVersion            = "2.3.3"
 val scalaTestVersion            = "3.0.8"
-val kryoVersion                 = "1.0.0"
+val kryoVersion                 = "1.1.0"
 val s3mockVersion               = "0.2.5"
 val apacheCommonsVersion        = "3.9"
 

--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -66,16 +66,21 @@ akka {
       "ch.epfl.bluebrain.nexus.sourcing.projections.StreamSupervisor$FetchLatestState$" = kryo
       "ch.epfl.bluebrain.nexus.sourcing.projections.StreamSupervisor$LatestState"       = kryo
 
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$Start"                = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$Stop"                 = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$ViewsAddedOrModified" = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$ViewsRemoved"         = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$ProjectChanges"       = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$FetchProgress"        = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$Start"                      = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$Stop"                       = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$ViewsAddedOrModified"       = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$RestartView"                = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$RestartProjections"         = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$ViewsRemoved"               = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$ProjectChanges"             = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$FetchOffset"                = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$FetchProjectionOffset"      = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$FetchStatistics"            = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor$Msg$FetchProjectionStatistics"  = kryo
 
       "ch.epfl.bluebrain.nexus.kg.async.ProjectAttributesCoordinatorActor$Msg$Start"            = kryo
       "ch.epfl.bluebrain.nexus.kg.async.ProjectAttributesCoordinatorActor$Msg$Stop"             = kryo
-      "ch.epfl.bluebrain.nexus.kg.async.ProjectAttributesCoordinatorActor$Msg$FetchProgress"    = kryo
+      "ch.epfl.bluebrain.nexus.kg.async.ProjectAttributesCoordinatorActor$Msg$FetchStatistics"  = kryo
 
       "ch.epfl.bluebrain.nexus.kg.archives.ArchiveCache$Request$Read"    = kryo
       "ch.epfl.bluebrain.nexus.kg.archives.ArchiveCache$Request$Write"   = kryo

--- a/src/main/resources/cassandra.conf
+++ b/src/main/resources/cassandra.conf
@@ -32,7 +32,7 @@ cassandra-journal {
     max-message-batch-size = ${?CASSANDRA_TAGS_MAX_BATCH_SIZE}
 
     # Max time to buffer events for before writing.
-    # Larger valeues will increase cassandra write efficiency but increase the delay before
+    # Larger values will increase cassandra write efficiency but increase the delay before
     # seeing events in EventsByTag queries.
     # Setting this to 0 means that tag writes will get written immediately but will still be asynchronous
     # with respect to the PersistentActor's persist call. However, this will be very bad for throughput.
@@ -40,7 +40,7 @@ cassandra-journal {
     flush-interval = ${?CASSANDRA_TAGS_FLUSH_INTERVAL}
 
     # Update the tag_scanning table with this interval. Shouldn't be done too often to
-    # avoid unecessary load. The tag_scanning table keeps track of a starting point for tag
+    # avoid unnecessary load. The tag_scanning table keeps track of a starting point for tag
     # scanning during recovery of persistent actor.
     scanning-flush-interval = 30s
     scanning-flush-interval = ${?CASSANDRA_TAGS_SCANNING_FLUSH_INTERVAL}

--- a/src/main/resources/contexts/progress-context.json
+++ b/src/main/resources/contexts/progress-context.json
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "@vocab": "https://bluebrain.github.io/nexus/vocabulary/"
+  }
+}

--- a/src/main/resources/elasticsearch/default-context.json
+++ b/src/main/resources/elasticsearch/default-context.json
@@ -7,11 +7,26 @@
       "@id": "https://bluebrain.github.io/nexus/vocabulary/project",
       "@type": "@id"
     },
-    "_self": "https://bluebrain.github.io/nexus/vocabulary/self",
-    "_incoming": "https://bluebrain.github.io/nexus/vocabulary/incoming",
-    "_outgoing": "https://bluebrain.github.io/nexus/vocabulary/outgoing",
-    "_updatedBy": "https://bluebrain.github.io/nexus/vocabulary/updatedBy",
-    "_createdBy": "https://bluebrain.github.io/nexus/vocabulary/createdBy",
+    "_self": {
+      "@id": "https://bluebrain.github.io/nexus/vocabulary/self",
+      "@type": "@id"
+    },
+    "_incoming": {
+      "@id": "https://bluebrain.github.io/nexus/vocabulary/incoming",
+      "@type": "@id"
+    },
+    "_outgoing": {
+      "@id": "https://bluebrain.github.io/nexus/vocabulary/outgoing",
+      "@type": "@id"
+    },
+    "_updatedBy": {
+      "@id": "https://bluebrain.github.io/nexus/vocabulary/updatedBy",
+      "@type": "@id"
+    },
+    "_createdBy": {
+      "@id": "https://bluebrain.github.io/nexus/vocabulary/createdBy",
+      "@type": "@id"
+    },
     "_storage": {
       "@id": "https://bluebrain.github.io/nexus/vocabulary/storage",
       "@type": "@id"

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectAttributesCoordinator.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectAttributesCoordinator.scala
@@ -45,7 +45,7 @@ class ProjectAttributesCoordinator[F[_]](projectCache: ProjectCache[F], ref: Act
     */
   def statistics(project: Project): F[Statistics] = {
     lazy val label = project.show
-    IO.fromFuture(IO(ref ? FetchProgress(project.uuid)))
+    IO.fromFuture(IO(ref ? FetchStatistics(project.uuid)))
       .to[F]
       .flatMap[Statistics] {
         case s: Statistics => F.pure(s)

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinator.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinator.scala
@@ -189,20 +189,16 @@ class ProjectViewCoordinator[F[_]](cache: Caches[F], ref: ActorRef)(
     *
     * @param projectRef the project unique identifier
     */
-  def stop(projectRef: ProjectRef): F[Unit] = {
-    ref ! Stop(projectRef.id)
-    F.unit
-  }
+  def stop(projectRef: ProjectRef): F[Unit] =
+    F.delay(ref ! Stop(projectRef.id))
 
   /**
     * Triggers restart of a view from the initial progress.
     *
     * @param view the view to be restarted
     */
-  def restart(view: IndexedView)(implicit project: Project): F[Unit] = {
-    ref ! RestartView(project.uuid, view)
-    F.unit
-  }
+  def restart(view: IndexedView)(implicit project: Project): F[Unit] =
+    F.delay(ref ! RestartView(project.uuid, view))
 
   /**
     * Triggers restart of a composite view where the passed projection will start from the initial progress.
@@ -219,28 +215,23 @@ class ProjectViewCoordinator[F[_]](cache: Caches[F], ref: ActorRef)(
     * @param project project to which the view belongs
     * @param view    the view to be restarted
     */
-  def restartProjections(view: CompositeView)(implicit project: Project): F[Unit] = {
-    ref ! RestartProjections(project.uuid, view, view.projections.map(_.view))
-    F.unit
-  }
+  def restartProjections(view: CompositeView)(implicit project: Project): F[Unit] =
+    F.delay(ref ! RestartProjections(project.uuid, view, view.projections.map(_.view)))
 
-  private def restart(view: CompositeView, restartOffsetViews: Set[SingleView])(implicit project: Project): F[Unit] = {
-    ref ! RestartProjections(project.uuid, view, restartOffsetViews)
-    F.unit
-  }
+  private def restart(view: CompositeView, restartOffsetViews: Set[SingleView])(implicit project: Project): F[Unit] =
+    F.delay(ref ! RestartProjections(project.uuid, view, restartOffsetViews))
 
   /**
     * Notifies the underlying coordinator actor about a change occurring to the Project
     * whenever this change is relevant to the coordinator
     *
-    * @param newProject the new uncoming project
+    * @param newProject the new incoming project
     * @param project    the previous state of the project
     */
-  def change(newProject: Project, project: Project): F[Unit] = {
+  def change(newProject: Project, project: Project): F[Unit] =
     if (newProject.label != project.label || newProject.organizationLabel != project.organizationLabel)
-      ref ! ProjectChanges(newProject.uuid, newProject)
-    F.unit
-  }
+      F.delay(ref ! ProjectChanges(newProject.uuid, newProject))
+    else F.unit
 }
 
 object ProjectViewCoordinator {

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinator.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinator.scala
@@ -2,18 +2,22 @@ package ch.epfl.bluebrain.nexus.kg.async
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.{ask, AskTimeoutException}
+import akka.persistence.query.Offset
 import akka.util.Timeout
-import cats.effect.{Async, IO}
+import cats.effect.{Async, ContextShift, IO}
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.admin.client.types.Project
+import ch.epfl.bluebrain.nexus.commons.search.QueryResult.UnscoredQueryResult
+import ch.epfl.bluebrain.nexus.commons.search.QueryResults
+import ch.epfl.bluebrain.nexus.commons.search.QueryResults.UnscoredQueryResults
 import ch.epfl.bluebrain.nexus.kg.KgError
 import ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor.Msg._
 import ch.epfl.bluebrain.nexus.kg.cache.Caches
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig
 import ch.epfl.bluebrain.nexus.kg.indexing.Statistics
-import ch.epfl.bluebrain.nexus.kg.indexing.View.{IndexedView, SingleView}
+import ch.epfl.bluebrain.nexus.kg.indexing.View.{CompositeView, IndexedView, SingleView}
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
-import ch.epfl.bluebrain.nexus.kg.resources.{OrganizationRef, ProjectRef, Resources}
+import ch.epfl.bluebrain.nexus.kg.resources.{IdentifiedValue, OrganizationRef, ProjectRef, Resources}
 import ch.epfl.bluebrain.nexus.kg.routes.Clients
 import ch.epfl.bluebrain.nexus.sourcing.projections.Projections
 import journal.Logger
@@ -36,39 +40,126 @@ class ProjectViewCoordinator[F[_]](cache: Caches[F], ref: ActorRef)(
     ec: ExecutionContext
 ) {
 
-  private implicit val timeout: Timeout = config.sourcing.askTimeout
-  private val log                       = Logger[this.type]
-  private implicit val contextShift     = IO.contextShift(ec)
+  private implicit val timeout: Timeout               = config.sourcing.askTimeout
+  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ec)
+  private val log                                     = Logger[this.type]
 
   /**
     * Fetches view statistics for a given view.
     *
-    * @param project  project to which the view belongs.
-    * @param view     the view to fetch the statistics for.
+    * @param view the view to fetch the statistics for
     * @return [[Statistics]] wrapped in [[F]]
     */
-  def statistics(project: Project, view: SingleView): F[Statistics] = {
+  def statistics(view: IndexedView)(implicit project: Project): F[Statistics] = {
     lazy val label = project.show
-    IO.fromFuture(IO(ref ? FetchProgress(project.uuid, view)))
+    IO.fromFuture(IO(ref ? FetchStatistics(project.uuid, view)))
       .to[F]
       .flatMap[Statistics] {
-        case s: Statistics => F.pure(s)
+        case value: Statistics => F.pure(value)
         case other =>
           val msg = s"Received unexpected reply from the project view coordinator actor: '$other' for project '$label'."
-          log.error(msg)
           F.raiseError(KgError.InternalError(msg))
       }
-      .recoverWith {
-        case _: AskTimeoutException =>
-          F.raiseError(
-            KgError
-              .OperationTimedOut(s"Timeout when asking for statistics to project view coordinator for project '$label'")
-          )
-        case NonFatal(th) =>
-          val msg = s"Exception caught while exchanging messages with the project view coordinator for project '$label'"
-          log.error(msg, th)
+      .recoverWith(logAndRaiseError(label, "statistics"))
+  }
+
+  /**
+    * Fetches view statistics for a given projection.
+    *
+    * @param view           the composite view where the projection belongs to
+    * @param projectionView the view to fetch the statistics for
+    * @return [[Statistics]] wrapped in [[F]]
+    */
+  def statistics(view: CompositeView, projectionView: SingleView)(implicit project: Project): F[Statistics] = {
+    lazy val label = project.show
+    IO.fromFuture(IO(ref ? FetchProjectionStatistics(project.uuid, view, projectionView)))
+      .to[F]
+      .flatMap[Statistics] {
+        case value: Statistics => F.pure(value)
+        case other =>
+          val msg = s"Received unexpected reply from the project view coordinator actor: '$other' for project '$label'."
           F.raiseError(KgError.InternalError(msg))
       }
+      .recoverWith(logAndRaiseError(label, "statistics"))
+  }
+
+  /**
+    * Fetches view offset.
+    *
+    * @param view the view to fetch the statistics for
+    * @return [[Offset]] wrapped in [[F]]
+    */
+  def offset(view: IndexedView)(implicit project: Project): F[Offset] = {
+    lazy val label = project.show
+    IO.fromFuture(IO(ref ? FetchOffset(project.uuid, view)))
+      .to[F]
+      .flatMap[Offset] {
+        case value: Offset => F.pure(value)
+        case other =>
+          val msg = s"Received unexpected reply from the project view coordinator actor: '$other' for project '$label'."
+          F.raiseError(KgError.InternalError(msg))
+      }
+      .recoverWith(logAndRaiseError(label, "progress"))
+  }
+
+  /**
+    * Fetches view offset for a given projection.
+    *
+    * @param view           the composite view where the projection belongs to
+    * @param projectionView the view to fetch the offset for
+    * @return [[Offset]] wrapped in [[F]]
+    */
+  def offset(view: CompositeView, projectionView: SingleView)(implicit project: Project): F[Offset] = {
+    lazy val label = project.show
+    IO.fromFuture(IO(ref ? FetchProjectionOffset(project.uuid, view, projectionView)))
+      .to[F]
+      .flatMap[Offset] {
+        case value: Offset => F.pure(value)
+        case other =>
+          val msg = s"Received unexpected reply from the project view coordinator actor: '$other' for project '$label'."
+          F.raiseError(KgError.InternalError(msg))
+      }
+      .recoverWith(logAndRaiseError(label, "progress"))
+  }
+
+  /**
+    * Fetches statistics for all projections inside a composite view.
+    *
+    * @param view the view to fetch the statistics for
+    * @return [[QueryResults[Statistics]]] wrapped in [[F]]
+    */
+  def projectionsStatistic(
+      view: CompositeView
+  )(implicit project: Project): F[QueryResults[IdentifiedValue[Statistics]]] =
+    view.projections.toList
+      .map(_.view)
+      .map(projectionView => statistics(view, projectionView).map(IdentifiedValue(projectionView.id, _)))
+      .sequence
+      .map(results => UnscoredQueryResults(results.size.toLong, results.map(UnscoredQueryResult.apply)))
+
+  /**
+    * Fetches progress for all projections inside a composite view.
+    *
+    * @param view the view to fetch the statistics for
+    * @return [[QueryResults[Offset]]] wrapped in [[F]]
+    */
+  def projectionsOffset(view: CompositeView)(implicit project: Project): F[QueryResults[IdentifiedValue[Offset]]] =
+    view.projections.toList
+      .map(_.view)
+      .map(projectionView => offset(view, projectionView).map(IdentifiedValue(projectionView.id, _)))
+      .sequence
+      .map(results => UnscoredQueryResults(results.size.toLong, results.map(UnscoredQueryResult.apply)))
+
+  private def logAndRaiseError[A](label: String, action: String): PartialFunction[Throwable, F[A]] = {
+    case _: AskTimeoutException =>
+      F.raiseError(
+        KgError
+          .OperationTimedOut(s"Timeout when asking for $action to project view coordinator for project '$label'")
+      )
+    case NonFatal(th) =>
+      val msg = s"Exception caught while exchanging messages with the project view coordinator for project '$label'"
+      log.error(msg, th)
+      F.raiseError(KgError.InternalError(msg))
   }
 
   /**
@@ -104,7 +195,42 @@ class ProjectViewCoordinator[F[_]](cache: Caches[F], ref: ActorRef)(
   }
 
   /**
-    * Notifies the underlying coordinator actor about a change ocurring to the Project
+    * Triggers restart of a view from the initial progress.
+    *
+    * @param view the view to be restarted
+    */
+  def restart(view: IndexedView)(implicit project: Project): F[Unit] = {
+    ref ! RestartView(project.uuid, view)
+    F.unit
+  }
+
+  /**
+    * Triggers restart of a composite view where the passed projection will start from the initial progress.
+    *
+    * @param view              the view to be restarted
+    * @param restartOffsetView the projection view for which the offset is restarted
+    */
+  def restart(view: CompositeView, restartOffsetView: SingleView)(implicit project: Project): F[Unit] =
+    restart(view, Set(restartOffsetView))
+
+  /**
+    * Triggers restart of a composite view where all the projection will start from the initial progress.
+    *
+    * @param project project to which the view belongs
+    * @param view    the view to be restarted
+    */
+  def restartProjections(view: CompositeView)(implicit project: Project): F[Unit] = {
+    ref ! RestartProjections(project.uuid, view, view.projections.map(_.view))
+    F.unit
+  }
+
+  private def restart(view: CompositeView, restartOffsetViews: Set[SingleView])(implicit project: Project): F[Unit] = {
+    ref ! RestartProjections(project.uuid, view, restartOffsetViews)
+    F.unit
+  }
+
+  /**
+    * Notifies the underlying coordinator actor about a change occurring to the Project
     * whenever this change is relevant to the coordinator
     *
     * @param newProject the new uncoming project

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorActor.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorActor.scala
@@ -1,13 +1,11 @@
 package ch.epfl.bluebrain.nexus.kg.async
 
-import java.time.Instant
 import java.util.UUID
 
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props, Stash}
 import akka.cluster.sharding.ShardRegion.{ExtractEntityId, ExtractShardId}
 import akka.cluster.sharding.{ClusterSharding, ClusterShardingSettings, ShardRegion}
 import akka.pattern.pipe
-import akka.persistence.query.{NoOffset, Offset, Sequence, TimeBasedUUID}
 import akka.stream.scaladsl.Source
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.admin.client.types.Project
@@ -15,7 +13,6 @@ import ch.epfl.bluebrain.nexus.commons.cache.KeyValueStoreSubscriber.KeyValueSto
 import ch.epfl.bluebrain.nexus.commons.cache.KeyValueStoreSubscriber.KeyValueStoreChanges
 import ch.epfl.bluebrain.nexus.commons.cache.OnKeyValueStoreChange
 import ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor.Msg._
-import ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinatorActor.OffsetSyntax
 import ch.epfl.bluebrain.nexus.kg.cache.ViewCache
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig._
@@ -26,7 +23,7 @@ import ch.epfl.bluebrain.nexus.kg.resources.{Event, Resources}
 import ch.epfl.bluebrain.nexus.kg.routes.Clients
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import ch.epfl.bluebrain.nexus.sourcing.projections.ProgressFlow.ProgressFlowElem
-import ch.epfl.bluebrain.nexus.sourcing.projections.ProjectionProgress.NoProgress
+import ch.epfl.bluebrain.nexus.sourcing.projections.ProjectionProgress.{NoProgress, SingleProgress}
 import ch.epfl.bluebrain.nexus.sourcing.projections._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -34,6 +31,7 @@ import shapeless.TypeCase
 
 import scala.collection.immutable.Set
 import scala.collection.mutable
+import scala.concurrent.Future
 
 /**
   * Coordinator backed by akka actor which runs the views' streams inside the provided project
@@ -59,19 +57,21 @@ private abstract class ProjectViewCoordinatorActor(viewCache: ViewCache[Task])(
       children ++= views.map(view => view -> startCoordinator(view, project, restartOffset = false))
       projectStream = Some(startProjectStream(project))
       unstashAll()
-    case FetchProgress(_, view) => val _ = viewProgress(view).runToFuture pipeTo sender()
     case other =>
       log.debug("Received non Start message '{}', stashing until the actor is initialized", other)
       stash()
   }
 
-  private def viewProgress(view: SingleView): Task[Statistics] = {
-    val viewProgress =
-      children.get(view).map(projectionProgress).getOrElse(Task.pure(NoProgress)).map(_.progress(view.progressId))
+  private def progress(mainView: IndexedView, singleViewOpt: Option[SingleView] = None): Task[SingleProgress] = {
+    val progressId = singleViewOpt.map(_.progressId).getOrElse(mainView.progressId)
+    children.get(mainView).map(projectionProgress).getOrElse(Task.pure(NoProgress)).map(_.progress(progressId))
+  }
+
+  private def statistics(view: IndexedView, singleViewOpt: Option[SingleView] = None): Task[Statistics] = {
     val projectProgress =
       projectStream.map(projectionProgress).getOrElse(Task.pure(NoProgress)).map(_.minProgress)
     for {
-      vp <- viewProgress
+      vp <- progress(view, singleViewOpt)
       pp <- projectProgress
     } yield Statistics(
       vp.processed,
@@ -118,6 +118,20 @@ private abstract class ProjectViewCoordinatorActor(viewCache: ViewCache[Task])(
   ): StreamSupervisor[Task, ProjectionProgress]
 
   /**
+    * Triggered in order to build an indexer actor for a provided composite view with ability to reset the projection offset to NoOffset
+    *
+    * @param view               the view from where to create the indexer actor
+    * @param project            the project of the current coordinator
+    * @param restartOffsetViews the set of projection views for which the offset is restarted
+    * @return the actor reference
+    */
+  def startCoordinator(
+      view: CompositeView,
+      project: Project,
+      restartOffsetViews: Set[SingleView]
+  ): StreamSupervisor[Task, ProjectionProgress]
+
+  /**
     * Triggered once an indexer actor has been stopped to clean up the indices
     *
     * @param view    the view linked to the indexer actor
@@ -131,24 +145,33 @@ private abstract class ProjectViewCoordinatorActor(viewCache: ViewCache[Task])(
   def onChange: OnKeyValueStoreChange[AbsoluteIri, View]
 
   def initialized(project: Project): Receive = {
+
+    // format: off
+    def logStop(view: View, reason: String): Unit =
+      log.info("View '{}' is going to be stopped at revision '{}' for project '{}'. Reason: '{}'.", view.id, view.rev, project.show, reason)
+
+    def logStart(view: View, extra: String): Unit =
+      log.info("View '{}' is going to be started at revision '{}' for project '{}'. {}.", view.id, view.rev, project.show, extra)
+    // format: on
+
     def stopView(
         v: IndexedView,
         coordinator: StreamSupervisor[Task, ProjectionProgress],
         deleteIndices: Boolean = true
-    ) = {
+    ): Future[Unit] = {
       children -= v
       (coordinator.stop() >> (if (deleteIndices) deleteViewIndices(v, project) else Task.unit)).runToFuture
     }
 
-    def startView(view: IndexedView, restartOffset: Boolean) = {
-      log.info(
-        "View '{}' is going to be started at revision '{}' for project '{}'. restartOffset: {}",
-        view.id,
-        view.rev,
-        project.show,
-        restartOffset
-      )
+    def startView(view: IndexedView, restartOffset: Boolean): Unit = {
+      logStart(view, s"restartOffset: '$restartOffset'")
       val ref = startCoordinator(view, project, restartOffset)
+      children += view -> ref
+    }
+
+    def startProjectionsView(view: CompositeView, restartOffsetViews: Set[SingleView]): Unit = {
+      logStart(view, s"restartOffset for projections: '${restartOffsetViews.map(_.progressId)}'")
+      val ref = startCoordinator(view, project, restartOffsetViews)
       children += view -> ref
     }
 
@@ -163,16 +186,10 @@ private abstract class ProjectViewCoordinatorActor(viewCache: ViewCache[Task])(
                   v -> ref
               }
               .foreach {
-                case (oldView, ref) =>
+                case (old, ref) =>
                   startView(view, restartOffset)
-                  log.info(
-                    "View '{}' is going to be stopped at revision '{}' for project '{}' because another view is going to be started. restartOffset: {}",
-                    oldView.id,
-                    oldView.rev,
-                    project.show,
-                    restartOffset
-                  )
-                  stopView(oldView, ref)
+                  logStop(old, s"a new rev of the same view is going to be started, restartOffset '$restartOffset'")
+                  stopView(old, ref)
               }
           case _ =>
         }
@@ -180,12 +197,7 @@ private abstract class ProjectViewCoordinatorActor(viewCache: ViewCache[Task])(
       case ViewsRemoved(_, views) =>
         children.filterKeys(v => views.exists(_.id == v.id)).foreach {
           case (v, ref) =>
-            log.info(
-              "View '{}' is going to be stopped at revision '{}' for project '{}' because it was removed from the cache.",
-              v.id,
-              v.rev,
-              project.show
-            )
+            logStop(v, "removed from the cache")
             stopView(v, ref)
         }
 
@@ -193,34 +205,50 @@ private abstract class ProjectViewCoordinatorActor(viewCache: ViewCache[Task])(
         context.become(initialized(newProject))
         children.foreach {
           case (view, ref) =>
-            log.info(
-              "View '{}' is going to be stopped at revision '{}' for project '{}' because the project has changes that require restart of the view.",
-              view.id,
-              view.rev,
-              project.show
-            )
+            logStop(view, "project changed")
             stopView(view, ref).map(_ => self ! ViewsAddedOrModified(project.uuid, restartOffset = true, Set(view)))
+        }
+
+      case RestartView(_, view) =>
+        children.find { case (v, _) => v.id == view.id }.foreach {
+          case (v, ref) =>
+            logStop(v, "restart triggered from client")
+            stopView(v, ref, deleteIndices = false)
+              .map(_ => self ! ViewsAddedOrModified(project.uuid, restartOffset = true, Set(view)))
+        }
+
+      case RestartProjections(_, view, projections) =>
+        children.collectFirst { case (v: CompositeView, ref) if v.id == view.id => view -> ref }.foreach {
+          case (v, ref) =>
+            logStop(v, "restart triggered from client")
+            stopView(v, ref, deleteIndices = false).map(_ => startProjectionsView(view, projections))
         }
 
       case Stop(_) =>
         children.foreach {
           case (view, ref) =>
-            log.info(
-              "View '{}' is going to be stopped at revision '{}' for project '{}' because the project or organization has been deprecated.",
-              view.id,
-              view.rev,
-              project.show
-            )
+            logStop(view, "deprecated organization")
             stopView(view, ref, deleteIndices = false)
         }
 
-      case FetchProgress(_, view) => val _ = viewProgress(view).runToFuture pipeTo sender()
+      case FetchOffset(_, view) =>
+        val _ = progress(view).map(_.offset).runToFuture pipeTo sender()
+
+      case FetchStatistics(_, view) =>
+        val _ = statistics(view).runToFuture pipeTo sender()
+
+      case FetchProjectionStatistics(_, mainView, projection) =>
+        val _ = statistics(mainView, Some(projection)).runToFuture pipeTo sender()
+
+      case FetchProjectionOffset(_, mainView, projection) =>
+        val _ = progress(mainView, Some(projection)).map(_.offset).runToFuture pipeTo sender()
 
       case _: Start => //ignore, it has already been started
 
       case other => log.error("Unexpected message received '{}'", other)
 
     }
+
   }
 
 }
@@ -236,12 +264,17 @@ object ProjectViewCoordinatorActor {
   }
   object Msg {
 
-    final case class Start(uuid: UUID, project: Project, views: Set[IndexedView])                      extends Msg
-    final case class Stop(uuid: UUID)                                                                  extends Msg
-    final case class ViewsAddedOrModified(uuid: UUID, restartOffset: Boolean, views: Set[IndexedView]) extends Msg
-    final case class ViewsRemoved(uuid: UUID, views: Set[IndexedView])                                 extends Msg
-    final case class ProjectChanges(uuid: UUID, project: Project)                                      extends Msg
-    final case class FetchProgress(uuid: UUID, view: SingleView)                                       extends Msg
+    final case class Start(uuid: UUID, project: Project, views: Set[IndexedView])                           extends Msg
+    final case class Stop(uuid: UUID)                                                                       extends Msg
+    final case class ViewsAddedOrModified(uuid: UUID, restartOffset: Boolean, views: Set[IndexedView])      extends Msg
+    final case class RestartView(uuid: UUID, view: IndexedView)                                             extends Msg
+    final case class RestartProjections(uuid: UUID, view: CompositeView, projectionViews: Set[SingleView])  extends Msg
+    final case class ViewsRemoved(uuid: UUID, views: Set[IndexedView])                                      extends Msg
+    final case class ProjectChanges(uuid: UUID, project: Project)                                           extends Msg
+    final case class FetchOffset(uuid: UUID, view: IndexedView)                                             extends Msg
+    final case class FetchProjectionOffset(uuid: UUID, view: CompositeView, projectionView: SingleView)     extends Msg
+    final case class FetchStatistics(uuid: UUID, view: IndexedView)                                         extends Msg
+    final case class FetchProjectionStatistics(uuid: UUID, view: CompositeView, projectionView: SingleView) extends Msg
   }
 
   private[async] def shardExtractor(shards: Int): ExtractShardId = {
@@ -288,19 +321,24 @@ object ProjectViewCoordinatorActor {
             case v: CompositeView     => CompositeIndexer.start(v, resources, project, restartOffset)
           }
 
+        override def startCoordinator(
+            view: CompositeView,
+            project: Project,
+            restartOffsetViews: Set[SingleView]
+        ): StreamSupervisor[Task, ProjectionProgress] =
+          CompositeIndexer.start(view, resources, project, restartOffsetViews)
+
         override def deleteViewIndices(view: IndexedView, project: Project): Task[Unit] = {
-          def deleteIndex(v: SingleView): Task[Unit] = {
-            log.info("index '{}' is removed from project '{}'", v.index, project.show)
+          def delete(v: SingleView): Task[Unit] = {
+            log.info("Index '{}' is removed from project '{}'", v.index, project.show)
             v.deleteIndex >> Task.unit
           }
 
           view match {
             case v: SingleView =>
-              deleteIndex(v)
+              delete(v)
             case v: CompositeView =>
-              deleteIndex(v.defaultSparqlView) >>
-                v.projections.map(p => deleteIndex(p.view)).toList.sequence >>
-                Task.unit
+              delete(v.defaultSparqlView) >> v.projections.map(p => delete(p.view)).toList.sequence >> Task.unit
           }
         }
 
@@ -337,16 +375,4 @@ object ProjectViewCoordinatorActor {
 
       }
     }
-
-  private[async] implicit class OffsetSyntax(offset: Offset) {
-
-    val NUM_100NS_INTERVALS_SINCE_UUID_EPOCH = 0X01B21DD213814000L
-
-    def asInstant: Option[Instant] = offset match {
-      case NoOffset | Sequence(_) => None
-      case TimeBasedUUID(uuid)    =>
-        //adapted from https://support.datastax.com/hc/en-us/articles/204226019-Converting-TimeUUID-Strings-to-Dates
-        Some(Instant.ofEpochMilli((uuid.timestamp - NUM_100NS_INTERVALS_SINCE_UUID_EPOCH) / 10000))
-    }
-  }
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/AppConfig.scala
@@ -312,6 +312,7 @@ object AppConfig {
     tagCtxUri         -> tagCtx,
     fileAttrCtxUri    -> fileAttrCtx,
     statisticsCtxUri  -> statisticsCtx,
+    progressCtxUri    -> progressCtx,
     resourceCtxUri    -> resourceCtx,
     shaclCtxUri       -> shaclCtx,
     resolverCtxUri    -> resolverCtx,

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Contexts.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Contexts.scala
@@ -14,6 +14,7 @@ object Contexts {
   val archiveCtxUri: AbsoluteIri    = base + "archive.json"
   val fileAttrCtxUri: AbsoluteIri   = base + "file-attr.json"
   val statisticsCtxUri: AbsoluteIri = base + "statistics.json"
+  val progressCtxUri: AbsoluteIri   = base + "progress.json"
   val resourceCtxUri: AbsoluteIri   = base + "resource.json"
   val resolverCtxUri: AbsoluteIri   = base + "resolver.json"
   val viewCtxUri: AbsoluteIri       = base + "view.json"
@@ -25,6 +26,7 @@ object Contexts {
   val archiveCtx: Json    = jsonContentOf("/contexts/archive-context.json")
   val fileAttrCtx: Json   = jsonContentOf("/contexts/file-attr-context.json")
   val statisticsCtx: Json = jsonContentOf("/contexts/statistics-context.json")
+  val progressCtx: Json   = jsonContentOf("/contexts/progress-context.json")
   val resourceCtx: Json   = jsonContentOf("/contexts/resource-context.json")
   val resolverCtx: Json   = jsonContentOf("/contexts/resolver-context.json")
   val viewCtx: Json       = jsonContentOf("/contexts/view-context.json")

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Vocabulary.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/config/Vocabulary.scala
@@ -148,6 +148,9 @@ object Vocabulary {
     //Links property
     val paths = PrefixMapping.prefix("paths")
 
+    //Progress offset
+    val offset = PrefixMapping.prefix("offset")
+
     // @type platform ids
     val Archive                    = PrefixMapping.prefix("Archive")
     val UpdateFileAttributes       = PrefixMapping.prefix("UpdateFileAttributes")
@@ -173,6 +176,9 @@ object Vocabulary {
     val Authenticated              = PrefixMapping.prefix("Authenticated")
     val Anonymous                  = PrefixMapping.prefix("Anonymous")
     val AccessControlList          = PrefixMapping.prefix("AccessControlList")
+    val NoProgress                 = PrefixMapping.prefix("NoProgress")
+    val Sequential                 = PrefixMapping.prefix("Sequential")
+    val TimeBased                  = PrefixMapping.prefix("TimeBased")
   }
 
   /**

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/CompositeIndexer.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/CompositeIndexer.scala
@@ -9,11 +9,11 @@ import ch.epfl.bluebrain.nexus.admin.client.types.Project
 import ch.epfl.bluebrain.nexus.commons.sparql.client.{BlazegraphClient, SparqlWriteQuery}
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig._
-import ch.epfl.bluebrain.nexus.kg.indexing.View.{CompositeView, SparqlView}
+import ch.epfl.bluebrain.nexus.kg.indexing.View.{CompositeView, SingleView, SparqlView}
 import ch.epfl.bluebrain.nexus.kg.resources._
 import ch.epfl.bluebrain.nexus.kg.routes.Clients
 import ch.epfl.bluebrain.nexus.sourcing.projections.ProgressFlow.{Eval, PairMsg, ProgressFlowElem, ProgressFlowList}
-import ch.epfl.bluebrain.nexus.sourcing.projections.ProjectionProgress.NoProgress
+import ch.epfl.bluebrain.nexus.sourcing.projections.ProjectionProgress.{NoProgress, OffsetsProgress}
 import ch.epfl.bluebrain.nexus.sourcing.projections._
 import journal.Logger
 
@@ -26,18 +26,76 @@ object CompositeIndexer {
   private implicit val log: Logger = Logger[CompositeIndexer.type]
 
   /**
-    * Starts the index process for an CompositeIndexer
+    * Starts the index process for a CompositeIndexer with the ability to reset the offset to NoOffset on the passed projections
+    *
+    * @param view               the view for which to start the index
+    * @param resources          the resources operations
+    * @param project            the project to which the resource belongs
+    * @param restartOffsetViews the set of projection views for which the offset is restarted
+    */
+  final def start[F[_]: Timer: Clients: Effect](
+      view: CompositeView,
+      resources: Resources[F],
+      project: Project,
+      restartOffsetViews: Set[SingleView]
+  )(
+      implicit as: ActorSystem,
+      actorInitializer: (Props, String) => ActorRef,
+      config: AppConfig,
+      projections: Projections[F, String]
+  ): StreamSupervisor[F, ProjectionProgress] = {
+
+    val progressId: String = view.defaultSparqlView.progressId
+
+    val initialProgressF = projections
+      .progress(progressId)
+      .map {
+        case progress: OffsetsProgress =>
+          restartOffsetViews.foldLeft(progress) { (newProgress, pView) =>
+            newProgress.replace(pView.progressId -> NoProgress)
+          }
+        case other => other // Do nothing, a composite view cannot be a single progress
+      }
+      .flatMap(newProgress => projections.recordProgress(progressId, newProgress) >> newProgress.pure[F])
+
+    start(view, resources, project, initialProgressF)
+  }
+
+  /**
+    * Starts the index process for a CompositeIndexer with the ability to restart the offset on the whole view
     *
     * @param view          the view for which to start the index
     * @param resources     the resources operations
     * @param project       the project to which the resource belongs
     * @param restartOffset a flag to decide whether to restart from the beginning or to resume from the previous offset
     */
-  final def start[F[_]: Timer](
+  final def start[F[_]: Timer: Clients](
       view: CompositeView,
       resources: Resources[F],
       project: Project,
       restartOffset: Boolean
+  )(
+      implicit as: ActorSystem,
+      actorInitializer: (Props, String) => ActorRef,
+      config: AppConfig,
+      projections: Projections[F, String],
+      F: Effect[F]
+  ): StreamSupervisor[F, ProjectionProgress] = {
+
+    val progressId: String = view.defaultSparqlView.progressId
+
+    val initialProgressF: F[ProjectionProgress] =
+      if (restartOffset) projections.recordProgress(progressId, NoProgress) >> F.pure(NoProgress)
+      else projections.progress(progressId)
+
+    start(view, resources, project, initialProgressF)
+  }
+
+  private def start[F[_]: Timer](
+      view: CompositeView,
+      resources: Resources[F],
+      project: Project,
+      initialProgressF: F[ProjectionProgress]
   )(
       implicit clients: Clients[F],
       as: ActorSystem,
@@ -47,8 +105,8 @@ object CompositeIndexer {
       F: Effect[F]
   ): StreamSupervisor[F, ProjectionProgress] = {
     val defaultView: SparqlView                         = view.defaultSparqlView
-    val name: String                                    = view.defaultSparqlView.progressId
-    val FSome: F[Option[Unit]]                          = F.delay(Option(()))
+    val progressId: String                              = view.progressId
+    val FSome: F[Option[Unit]]                          = F.pure(Option(()))
     implicit val ec: ExecutionContext                   = as.dispatcher
     implicit val proj: Project                          = project
     implicit val indexing: IndexingConfig               = config.sparql.indexing
@@ -63,15 +121,11 @@ object CompositeIndexer {
 
     val init = defaultView.createIndex >> view.projections.map(_.view.createIndex).toList.sequence >> F.unit
 
-    val initFetchProgressF: F[ProjectionProgress] =
-      if (restartOffset) projections.recordProgress(name, NoProgress) >> init >> F.delay(NoProgress)
-      else init >> projections.progress(name)
-
-    val sourceF: F[Source[ProjectionProgress, _]] = initFetchProgressF.map { initial =>
+    val sourceF: F[Source[ProjectionProgress, _]] = (init >> initialProgressF).map { initial =>
       Source.fromGraph(GraphDSL.create() { implicit b =>
         import GraphDSL.Implicits._
         // format: off
-        val source: Source[PairMsg[Any], _] = cassandraSource(s"project=${view.ref.id}", name, initial.minProgress.offset)
+        val source: Source[PairMsg[Any], _] = cassandraSource(s"project=${view.ref.id}", progressId, initial.minProgress.offset)
         val mainFlow = ProgressFlowElem[F, Any]
           .collectCast[Event]
           .groupedWithin(indexing.batch, indexing.batchTimeout)
@@ -82,31 +136,31 @@ object CompositeIndexer {
             case res if defaultView.allowedSchemas(res) && defaultView.allowedTypes(res) => res -> buildInsertOrDeleteQuery(res, defaultView)
             case res if defaultView.allowedSchemas(res) =>                                  res -> defaultView.buildDeleteQuery(res)
           }
-          .runAsyncBatch(list => sparqlClientIndex.bulk(list.map { case (_, bulkQuery) => bulkQuery }))(Eval.After(initial.progress(name).offset))
+          .runAsyncBatch(list => sparqlClientIndex.bulk(list.map { case (_, bulkQuery) => bulkQuery }))(Eval.After(initial.progress(progressId).offset))
           .map { case (res, _) => res }
           .mergeEmit()
 
         val projectionsFlow = view.projections.map { projection =>
-            val projView = projection.view
-            ProgressFlowElem[F, ResourceV]
-              .select(projView.progressId)
-              .evaluateAfter(initial.progress(projView.progressId).offset)
-              .collect {
-                case res if projView.allowedSchemas(res) && projView.allowedTypes(res) && projView.allowedTag(res) => res
-              }
-              .mapAsync(res => projection.runQuery(res).map(res -> _.asGraph))
-              .mapAsync {
-                case (res, None)                                 => projView.deleteResource[F](res.id) >> FSome
-                case (res, Some(graph)) if graph.triples.isEmpty => projView.deleteResource[F](res.id) >> FSome
-                case (res, Some(graph))                          => projection.indexId[F](res, graph)
-              }
-              .collectSome[Unit]
+          val projView = projection.view
+          ProgressFlowElem[F, ResourceV]
+            .select(projView.progressId)
+            .evaluateAfter(initial.progress(projView.progressId).offset)
+            .collect {
+              case res if projView.allowedSchemas(res) && projView.allowedTypes(res) && projView.allowedTag(res) => res
+            }
+            .mapAsync(res => projection.runQuery(res).map(res -> _.asGraph))
+            .mapAsync {
+              case (res, None)                                 => projView.deleteResource[F](res.id) >> FSome
+              case (res, Some(graph)) if graph.triples.isEmpty => projView.deleteResource[F](res.id) >> FSome
+              case (res, Some(graph))                          => projection.indexResourceGraph[F](res, graph)
+            }
+            .collectSome[Unit]
         }
 
         val broadcast = b.add(Broadcast[PairMsg[ResourceV]](view.projections.size))
         val merge     = b.add(ZipWithN[PairMsg[Unit], List[PairMsg[Unit]]](_.toList)(view.projections.size))
 
-        val persistFlow = b.add(ProgressFlowList[F, Unit].mergeCombine().toPersistedProgress(name, initial))
+        val persistFlow = b.add(ProgressFlowList[F, Unit].mergeCombine().toPersistedProgress(progressId, initial))
 
         source ~> mainFlow.flow ~> broadcast
                                    projectionsFlow.foreach(broadcast ~> _.flow ~> merge)
@@ -116,7 +170,7 @@ object CompositeIndexer {
         // format: on
       })
     }
-    StreamSupervisor.start(sourceF, name, actorInitializer)
+    StreamSupervisor.start(sourceF, progressId, actorInitializer)
   }
 }
 // $COVERAGE-ON$

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/ElasticSearchIndexer.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/ElasticSearchIndexer.scala
@@ -50,7 +50,7 @@ object ElasticSearchIndexer {
     implicit val ec: ExecutionContext          = as.dispatcher
     implicit val p: Project                    = project
     implicit val indexing: IndexingConfig      = config.elasticSearch.indexing
-    implicit val metadataOpts: MetadataOptions = MetadataOptions(linksAsIri = false, expandedLinks = true)
+    implicit val metadataOpts: MetadataOptions = MetadataOptions(linksAsIri = true, expandedLinks = true)
     val client: ElasticSearchClient[F]         = clients.elasticSearch.withRetryPolicy(config.elasticSearch.indexing.retry)
 
     def deleteOrIndex(res: ResourceV): Option[BulkOp] =
@@ -62,7 +62,7 @@ object ElasticSearchIndexer {
 
     val initFetchProgressF: F[ProjectionProgress] =
       if (restartOffset)
-        projections.recordProgress(view.progressId, NoProgress) >> view.createIndex >> F.delay(NoProgress)
+        projections.recordProgress(view.progressId, NoProgress) >> view.createIndex >> F.pure(NoProgress)
       else view.createIndex >> projections.progress(view.progressId)
 
     val sourceF: F[Source[ProjectionProgress, _]] = initFetchProgressF.map { initial =>

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/SparqlIndexer.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/indexing/SparqlIndexer.scala
@@ -56,7 +56,7 @@ object SparqlIndexer {
 
     val initFetchProgressF: F[ProjectionProgress] =
       if (restartOffset)
-        projections.recordProgress(view.progressId, NoProgress) >> view.createIndex >> F.delay(NoProgress)
+        projections.recordProgress(view.progressId, NoProgress) >> view.createIndex >> F.pure(NoProgress)
       else view.createIndex >> projections.progress(view.progressId)
 
     val sourceF: F[Source[ProjectionProgress, _]] = initFetchProgressF.map { initial =>

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/IdentifiedValue.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/resources/IdentifiedValue.scala
@@ -1,0 +1,24 @@
+package ch.epfl.bluebrain.nexus.kg.resources
+
+import cats.Functor
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import io.circe.{Encoder, Json}
+import io.circe.syntax._
+
+/**
+  * Represents a value and its identifier
+  *
+  * @param id    the identifier of the value
+  * @param value the value
+  */
+final case class IdentifiedValue[A](id: AbsoluteIri, value: A)
+
+object IdentifiedValue {
+  implicit def encoderIdentifiedValue[A: Encoder]: Encoder[IdentifiedValue[A]] = Encoder.instance {
+    case IdentifiedValue(id, value) => Json.obj("@id" -> id.asString.asJson) deepMerge value.asJson
+  }
+
+  implicit val functorIdentifiedValue: Functor[IdentifiedValue] = new Functor[IdentifiedValue] {
+    override def map[A, B](fa: IdentifiedValue[A])(f: A => B): IdentifiedValue[B] = fa.copy(value = f(fa.value))
+  }
+}

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ArchiveRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ArchiveRoutes.scala
@@ -41,7 +41,7 @@ class ArchiveRoutes private[routes] (archives: Archives[Task])(
     concat(
       // Create an archive when id is not provided in the Uri (POST)
       (post & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/archives/{}/{}") {
+        operationName(s"/${config.http.prefix}/archives/{org}/{project}") {
           (hasPermission(write) & projectNotDeprecated) {
             entity(as[Json]) { source =>
               val created = archives.create(source)
@@ -69,7 +69,7 @@ class ArchiveRoutes private[routes] (archives: Archives[Task])(
     concat(
       // Create archive
       (put & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/archives/{}/{}/{}") {
+        operationName(s"/${config.http.prefix}/archives/{org}/{project}/{id}") {
           (hasPermission(write) & projectNotDeprecated) {
             entity(as[Json]) { source =>
               complete(archives.create(resId, source).value.runWithStatus(Created))

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/EventRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/EventRoutes.scala
@@ -22,7 +22,7 @@ class EventRoutes(acls: AccessControlLists, caller: Caller)(implicit as: ActorSy
 
   def routes(project: Project): Route = {
     lastEventId { offset =>
-      operationName(s"/${config.http.prefix}/resources/{}/{}/events") {
+      operationName(s"/${config.http.prefix}/resources/{org}/{project}/events") {
         implicit val p: Project = project
         hasPermission(read).apply {
           complete(source(s"project=${project.uuid}", offset))
@@ -33,7 +33,7 @@ class EventRoutes(acls: AccessControlLists, caller: Caller)(implicit as: ActorSy
 
   def routes(org: Organization): Route =
     lastEventId { offset =>
-      operationName(s"/${config.http.prefix}/resources/{}/events") {
+      operationName(s"/${config.http.prefix}/resources/{org}/events") {
         hasPermission(read, org.label).apply {
           complete(source(s"org=${org.uuid}", offset))
         }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Routes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/Routes.scala
@@ -201,7 +201,7 @@ object Routes {
 
     def list(implicit acls: AccessControlLists, caller: Caller, project: Project): Route =
       (get & paginated & searchParams & pathEndOrSingleSlash) { (pagination, params) =>
-        operationName(s"/${config.http.prefix}/resources/{}/{}") {
+        operationName(s"/${config.http.prefix}/resources/{org}/{project}") {
           (hasPermission(read) & extractUri) { implicit uri =>
             val listed = viewCache.getDefaultElasticSearch(project.ref).flatMap(resources.list(_, params, pagination))
             complete(listed.runWithStatus(OK))
@@ -216,7 +216,7 @@ object Routes {
 
     def createDefault(implicit acls: AccessControlLists, caller: Caller, project: Project): Route =
       (post & noParameter('rev.as[Long]) & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/resources/{}/{}") {
+        operationName(s"/${config.http.prefix}/resources/{org}/{project}") {
           (hasPermission(ResourceRoutes.write) & projectNotDeprecated) {
             entity(as[Json]) { source =>
               complete(resources.create(unconstrainedRef, source).value.runWithStatus(Created))

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/SchemaRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/SchemaRoutes.scala
@@ -48,7 +48,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
     concat(
       // Create schema when id is not provided on the Uri (POST)
       (post & noParameter('rev.as[Long]) & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/schemas/{}/{}") {
+        operationName(s"/${config.http.prefix}/schemas/{org}/{project}") {
           Kamon.currentSpan().tag("resource.operation", "create")
           (hasPermission(write) & projectNotDeprecated) {
             entity(as[Json]) { source =>
@@ -59,7 +59,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
       },
       // List schemas
       (get & paginated & searchParams(fixedSchema = shaclSchemaUri) & pathEndOrSingleSlash) { (page, params) =>
-        operationName(s"/${config.http.prefix}/schemas/{}/{}") {
+        operationName(s"/${config.http.prefix}/schemas/{org}/{project}") {
           extractUri { implicit uri =>
             hasPermission(read).apply {
               val listed = viewCache.getDefaultElasticSearch(project.ref).flatMap(schemas.list(_, params, page))
@@ -86,7 +86,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
     concat(
       // Create or update a schema (depending on rev query parameter)
       (put & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/schemas/{}/{}/{}") {
+        operationName(s"/${config.http.prefix}/schemas/{org}/{project}/{id}") {
           (hasPermission(write) & projectNotDeprecated) {
             entity(as[Json]) { source =>
               parameter('rev.as[Long].?) {
@@ -103,7 +103,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
       },
       // Deprecate schema
       (delete & parameter('rev.as[Long]) & pathEndOrSingleSlash) { rev =>
-        operationName(s"/${config.http.prefix}/schemas/{}/{}/{}") {
+        operationName(s"/${config.http.prefix}/schemas/{org}/{project}/{id}") {
           (hasPermission(write) & projectNotDeprecated) {
             complete(schemas.deprecate(Id(project.ref, id), rev).value.runWithStatus(OK))
           }
@@ -111,7 +111,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
       },
       // Fetch schema
       (get & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/schemas/{}/{}/{}") {
+        operationName(s"/${config.http.prefix}/schemas/{org}/{project}/{id}") {
           outputFormat(strict = false, Compacted) {
             case format: NonBinaryOutputFormat =>
               hasPermission(read).apply {
@@ -133,7 +133,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
       },
       // Fetch schema source
       (get & pathPrefix("source") & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/schemas/{}/{}/{}/source") {
+        operationName(s"/${config.http.prefix}/schemas/{org}/{project}/{id}/source") {
           hasPermission(read).apply {
             concat(
               (parameter('rev.as[Long]) & noParameter('tag)) { rev =>
@@ -151,7 +151,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
       },
       // Incoming links
       (get & pathPrefix("incoming") & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/schemas/{}/{}/{}/incoming") {
+        operationName(s"/${config.http.prefix}/schemas/{org}/{project}/{id}/incoming") {
           fromPaginated.apply { implicit page =>
             extractUri { implicit uri =>
               hasPermission(read).apply {
@@ -165,7 +165,7 @@ class SchemaRoutes private[routes] (schemas: Schemas[Task], tags: Tags[Task])(
       // Outgoing links
       (get & pathPrefix("outgoing") & parameter('includeExternalLinks.as[Boolean] ? true) & pathEndOrSingleSlash) {
         links =>
-          operationName(s"/${config.http.prefix}/schemas/{}/{}/{}/outgoing") {
+          operationName(s"/${config.http.prefix}/schemas/{org}/{project}/{id}/outgoing") {
             fromPaginated.apply { implicit page =>
               extractUri { implicit uri =>
                 hasPermission(read).apply {

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/StorageRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/StorageRoutes.scala
@@ -50,7 +50,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
     concat(
       // Create storage when id is not provided on the Uri (POST)
       (post & noParameter('rev.as[Long]) & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/storages/{}/{}") {
+        operationName(s"/${config.http.prefix}/storages/{org}/{project}") {
           Kamon.currentSpan().tag("resource.operation", "create")
           (hasPermission(write) & projectNotDeprecated) {
             entity(as[Json]) { source =>
@@ -61,7 +61,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
       },
       // List storages
       (get & paginated & searchParams(fixedSchema = storageSchemaUri) & pathEndOrSingleSlash) { (page, params) =>
-        operationName(s"/${config.http.prefix}/storages/{}/{}") {
+        operationName(s"/${config.http.prefix}/storages/{org}/{project}") {
           extractUri { implicit uri =>
             hasPermission(read).apply {
               val listed = viewCache.getDefaultElasticSearch(project.ref).flatMap(storages.list(_, params, page))
@@ -88,7 +88,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
     concat(
       // Create or update a storage (depending on rev query parameter)
       (put & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/storages/{}/{}/{}") {
+        operationName(s"/${config.http.prefix}/storages/{org}/{project}/{id}") {
           (hasPermission(write) & projectNotDeprecated) {
             entity(as[Json]) { source =>
               parameter('rev.as[Long].?) {
@@ -105,7 +105,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
       },
       // Deprecate storage
       (delete & parameter('rev.as[Long]) & pathEndOrSingleSlash) { rev =>
-        operationName(s"/${config.http.prefix}/storages/{}/{}/{}") {
+        operationName(s"/${config.http.prefix}/storages/{org}/{project}/{id}") {
           (hasPermission(write) & projectNotDeprecated) {
             complete(storages.deprecate(Id(project.ref, id), rev).value.runWithStatus(OK))
           }
@@ -113,7 +113,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
       },
       // Fetch storage
       (get & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/storages/{}/{}/{}") {
+        operationName(s"/${config.http.prefix}/storages/{org}/{project}/{id}") {
           outputFormat(strict = false, Compacted) {
             case format: NonBinaryOutputFormat =>
               hasPermission(read).apply {
@@ -135,7 +135,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
       },
       // Fetch storage source
       (get & pathPrefix("source") & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/storages/{}/{}/{}/source") {
+        operationName(s"/${config.http.prefix}/storages/{org}/{project}/{id}/source") {
           hasPermission(read).apply {
             concat(
               (parameter('rev.as[Long]) & noParameter('tag)) { rev =>
@@ -153,7 +153,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
       },
       // Incoming links
       (get & pathPrefix("incoming") & pathEndOrSingleSlash) {
-        operationName(s"/${config.http.prefix}/storages/{}/{}/{}/incoming") {
+        operationName(s"/${config.http.prefix}/storages/{org}/{project}/{id}/incoming") {
           fromPaginated.apply { implicit page =>
             extractUri { implicit uri =>
               hasPermission(read).apply {
@@ -167,7 +167,7 @@ class StorageRoutes private[routes] (storages: Storages[Task], tags: Tags[Task])
       // Outgoing links
       (get & pathPrefix("outgoing") & parameter('includeExternalLinks.as[Boolean] ? true) & pathEndOrSingleSlash) {
         links =>
-          operationName(s"/${config.http.prefix}/storages/{}/{}/{}/outgoing") {
+          operationName(s"/${config.http.prefix}/storages/{org}/{project}/{id}/outgoing") {
             fromPaginated.apply { implicit page =>
               extractUri { implicit uri =>
                 hasPermission(read).apply {

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/TagRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/TagRoutes.scala
@@ -70,7 +70,7 @@ class TagRoutes private[routes] (resourceType: String, tags: Tags[Task], schema:
     Encoder.instance(tags => Json.obj(nxv.tags.prefix -> Json.arr(tags.map(_.asJson).toSeq: _*)).addContext(tagCtxUri))
 
   private def opName: String = resourceType match {
-    case "resources" => s"/${config.http.prefix}/resources/{}/{}/{}/{}/tags"
-    case _           => s"/${config.http.prefix}/$resourceType/{}/{}/{}/tags"
+    case "resources" => s"/${config.http.prefix}/resources/{org}/{project}/{schemaId}/{id}/tags"
+    case _           => s"/${config.http.prefix}/$resourceType/{org}/{project}/{id}/tags"
   }
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ViewRoutes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/kg/routes/ViewRoutes.scala
@@ -4,8 +4,12 @@ import akka.http.scaladsl.model.StatusCodes.{Created, OK}
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import cats.syntax.functor._
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import akka.persistence.query.{NoOffset, Offset, Sequence, TimeBasedUUID}
 import ch.epfl.bluebrain.nexus.admin.client.types.Project
+import ch.epfl.bluebrain.nexus.commons.search.QueryResults
+import ch.epfl.bluebrain.nexus.commons.search.QueryResults.UnscoredQueryResults
 import ch.epfl.bluebrain.nexus.commons.sparql.client.SparqlResults
 import ch.epfl.bluebrain.nexus.commons.test.Resources.jsonContentOf
 import ch.epfl.bluebrain.nexus.iam.client.types._
@@ -13,11 +17,14 @@ import ch.epfl.bluebrain.nexus.kg.KgError.InvalidOutputFormat
 import ch.epfl.bluebrain.nexus.kg.async.ProjectViewCoordinator
 import ch.epfl.bluebrain.nexus.kg.cache._
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig
+import ch.epfl.bluebrain.nexus.kg.config.Contexts._
 import ch.epfl.bluebrain.nexus.kg.config.Schemas._
+import ch.epfl.bluebrain.nexus.kg.config.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.kg.directives.AuthDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.PathDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.ProjectDirectives._
 import ch.epfl.bluebrain.nexus.kg.directives.QueryDirectives._
+import ch.epfl.bluebrain.nexus.kg.indexing.View.CompositeView.Projection.{ElasticSearchProjection, SparqlProjection}
 import ch.epfl.bluebrain.nexus.kg.indexing.View._
 import ch.epfl.bluebrain.nexus.kg.indexing.{Statistics, View}
 import ch.epfl.bluebrain.nexus.kg.marshallers.instances._
@@ -25,9 +32,12 @@ import ch.epfl.bluebrain.nexus.kg.resources.Rejection.{NoStatsForAggregateView, 
 import ch.epfl.bluebrain.nexus.kg.resources._
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
 import ch.epfl.bluebrain.nexus.kg.routes.OutputFormat._
+import ch.epfl.bluebrain.nexus.kg.routes.ViewRoutes._
 import ch.epfl.bluebrain.nexus.kg.search.QueryResultEncoder._
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
-import io.circe.Json
+import ch.epfl.bluebrain.nexus.rdf.syntax._
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
 import kamon.Kamon
 import kamon.instrumentation.akka.http.TracingDirectives.operationName
 import monix.eval.Task
@@ -99,16 +109,41 @@ class ViewRoutes private[routes] (
     */
   def routes(id: AbsoluteIri): Route =
     concat(
-      // Fetches view statistics
+      // Retrieves view statistics
       (get & pathPrefix("statistics") & pathEndOrSingleSlash) {
         operationName(s"/${config.http.prefix}/views/{}/{}/{}/statistics") {
           hasPermission(read).apply {
             val result: Task[Either[Rejection, Statistics]] = viewCache.getBy[View](project.ref, id).flatMap {
-              case Some(view: CompositeView) => coordinator.statistics(project, view.defaultSparqlView).map(Right(_))
-              case Some(view: SingleView)    => coordinator.statistics(project, view).map(Right(_))
-              case Some(_)                   => Task.pure(Left(NoStatsForAggregateView))
-              case None                      => Task.pure(Left(NotFound(id.ref)))
+              case Some(view: IndexedView) => coordinator.statistics(view).map(Right(_))
+              case Some(_)                 => Task.pure(Left(NoStatsForAggregateView))
+              case None                    => Task.pure(Left(NotFound(id.ref)))
             }
+            complete(result.runWithStatus(StatusCodes.OK))
+          }
+        }
+      },
+      // Retrieves progress for a view
+      (get & pathPrefix("progress") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/progress") {
+          hasPermission(read).apply {
+            val result: Task[Either[Rejection, ProgressWrapper]] = viewCache.getBy[View](project.ref, id).flatMap {
+              case Some(view: IndexedView) => coordinator.offset(view).map(off => Right(ProgressWrapper(off)))
+              case Some(_)                 => Task.pure(Left(NoStatsForAggregateView))
+              case None                    => Task.pure(Left(NotFound(id.ref)))
+            }
+            complete(result.runWithStatus(StatusCodes.OK))
+          }
+        }
+      },
+      // Delete progress from a view. This triggers view restart with initial progress
+      (delete & pathPrefix("progress") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/progress") {
+          hasPermission(write).apply {
+            val result: Task[Either[Rejection, ProgressWrapper]] =
+              viewCache.getBy[IndexedView](project.ref, id).flatMap {
+                case Some(view) => coordinator.restart(view) >> Task.pure(Right(ProgressWrapper.empty))
+                case None       => Task.pure(Left(NotFound(id.ref)))
+              }
             complete(result.runWithStatus(StatusCodes.OK))
           }
         }
@@ -228,13 +263,88 @@ class ViewRoutes private[routes] (
           }
       },
       new TagRoutes("views", tags, viewRef, write).routes(id),
-      // Consume the projection id segment
-      pathPrefix("projections" / IdSegment) { projectionId =>
-        routes(id, projectionId)
+      pathPrefix("projections") {
+        concat(
+          // Consume the projection id segment as underscore if present
+          pathPrefix("_") {
+            routesAllProjections(id)
+          },
+          // Consume the projection id segment
+          pathPrefix(IdSegment) { projectionId =>
+            routesProjection(id, projectionId)
+          }
+        )
       }
     )
 
-  private def routes(id: AbsoluteIri, projectionId: AbsoluteIri): Route =
+  private def routesAllProjections(id: AbsoluteIri): Route =
+    concat(
+      // Queries the ElasticSearch endpoint of every projection on an aggregated search
+      (post & pathPrefix("_search") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/_/_search") {
+          (hasPermission(query) & extract(_.request.uri.query())) { params =>
+            entity(as[Json]) { query =>
+              val result =
+                viewCache.getBy[CompositeView](project.ref, id).flatMap(runProjectionsSearch(params, id, query))
+              complete(result.runWithStatus(StatusCodes.OK))
+            }
+          }
+        }
+      },
+      // Queries the Sparql endpoint of every projection on an aggregated search
+      (post & pathPrefix("sparql") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/_/sparql") {
+          hasPermission(query).apply {
+            entity(as[String]) { query =>
+              val result = viewCache.getBy[CompositeView](project.ref, id).flatMap(runProjectionsSearch(id, query))
+              complete(result.runWithStatus(StatusCodes.OK))
+            }
+          }
+        }
+      },
+      // Retrieves statistics from all projections
+      (get & pathPrefix("statistics") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/_/statistics") {
+          hasPermission(read).apply {
+            val listed: Task[ListResults[Statistics]] =
+              viewCache.getBy[CompositeView](project.ref, id).flatMap {
+                case Some(view) => coordinator.projectionsStatistic(view)
+                case None       => Task.pure(UnscoredQueryResults(0L, List.empty))
+              }
+            complete(listed.runWithStatus(StatusCodes.OK))
+          }
+        }
+      },
+      // Retrieves progress from all projections
+      (get & pathPrefix("progress") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/_/progress") {
+          hasPermission(read).apply {
+            val listed: Task[ListResults[ProgressWrapper]] =
+              viewCache.getBy[CompositeView](project.ref, id).flatMap {
+                case Some(view) =>
+                  coordinator.projectionsOffset(view).map(_.map(_.map(ProgressWrapper(_))))
+                case None => Task.pure(UnscoredQueryResults(0L, List.empty))
+              }
+            complete(listed.runWithStatus(StatusCodes.OK))
+          }
+        }
+      },
+      // Delete progress from all projections. This triggers view restart with initial progress all projections
+      (delete & pathPrefix("progress") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/_/progress") {
+          hasPermission(write).apply {
+            val result: Task[Either[Rejection, ProgressWrapper]] =
+              viewCache.getBy[CompositeView](project.ref, id).flatMap {
+                case Some(view) => coordinator.restartProjections(view) >> Task.pure(Right(ProgressWrapper.empty))
+                case None       => Task.pure(Left(NotFound(id.ref)))
+              }
+            complete(result.runWithStatus(StatusCodes.OK))
+          }
+        }
+      }
+    )
+
+  private def routesProjection(id: AbsoluteIri, projectionId: AbsoluteIri): Route =
     concat(
       // Queries a projection view on the ElasticSearch endpoint
       (post & pathPrefix("_search") & pathEndOrSingleSlash) {
@@ -264,9 +374,35 @@ class ViewRoutes private[routes] (
         operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/{}/statistics") {
           hasPermission(read).apply {
             val result: Task[Either[Rejection, Statistics]] =
-              viewCache.getProjectionBy[SingleView](project.ref, id, projectionId).flatMap {
-                case Some(view) => coordinator.statistics(project, view).map(Right(_))
-                case None       => Task.pure(Left(NotFound(id.ref)))
+              viewCache.getViewAndProjectionBy[SingleView](project.ref, id, projectionId).flatMap {
+                case Some((view, pView)) => coordinator.statistics(view, pView).map(Right(_))
+                case None                => Task.pure(Left(NotFound(id.ref)))
+              }
+            complete(result.runWithStatus(StatusCodes.OK))
+          }
+        }
+      },
+      // Retrieves progress for a projection
+      (get & pathPrefix("progress") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/{}/progress") {
+          hasPermission(read).apply {
+            val result: Task[Either[Rejection, ProgressWrapper]] =
+              viewCache.getViewAndProjectionBy[SingleView](project.ref, id, projectionId).flatMap {
+                case Some((view, pView)) => coordinator.offset(view, pView).map(off => Right(ProgressWrapper(off)))
+                case None                => Task.pure(Left(NotFound(id.ref)))
+              }
+            complete(result.runWithStatus(StatusCodes.OK))
+          }
+        }
+      },
+      // Delete progress from a projection. This triggers view restart with initial progress for selected projection
+      (delete & pathPrefix("progress") & pathEndOrSingleSlash) {
+        operationName(s"/${config.http.prefix}/views/{}/{}/{}/projections/{}/progress") {
+          hasPermission(write).apply {
+            val result: Task[Either[Rejection, ProgressWrapper]] =
+              viewCache.getViewAndProjectionBy[SingleView](project.ref, id, projectionId).flatMap {
+                case Some((view, pView)) => coordinator.restart(view, pView) >> Task.pure(Right(ProgressWrapper.empty))
+                case None                => Task.pure(Left(NotFound(id.ref)))
               }
             complete(result.runWithStatus(StatusCodes.OK))
           }
@@ -287,17 +423,76 @@ class ViewRoutes private[routes] (
     case _ => Task.pure(Left(NotFound(id.ref)))
   }
 
+  private def runProjectionsSearch(
+      id: AbsoluteIri,
+      query: String
+  ): Option[CompositeView] => Task[Either[Rejection, SparqlResults]] = {
+    case Some(view) =>
+      val projectionViews = view.projectionsBy[SparqlProjection].map(_.view)
+      val resultListF     = Task.gatherUnordered(projectionViews.map(sparqlQuery(_, query)))
+      resultListF.map(list => Right(list.foldLeft(SparqlResults.empty)(_ ++ _)))
+    case _ =>
+      Task.pure(Left(NotFound(id.ref)))
+  }
+
+  private def runProjectionsSearch(
+      params: Uri.Query,
+      id: AbsoluteIri,
+      query: Json
+  ): Option[CompositeView] => Task[Either[Rejection, Json]] = {
+    case Some(view) => runSearchForIndices(params, query)(view.projectionsBy[ElasticSearchProjection].map(_.view.index))
+    case _          => Task.pure(Left(NotFound(id.ref)))
+  }
+
   private def runSearch(
       params: Uri.Query,
       id: AbsoluteIri,
       query: Json
   ): Option[View] => Task[Either[Rejection, Json]] = {
-    case Some(v: ElasticSearchView) => clients.elasticSearch.searchRaw(query, Set(v.index), params).map(Right.apply)
-    case Some(agg: AggregateElasticSearchView[_]) =>
-      agg.queryableIndices.flatMap {
-        case indices if indices.isEmpty => Task.pure[Either[Rejection, Json]](Right(emptyEsList))
-        case indices                    => clients.elasticSearch.searchRaw(query, indices, params).map(Right.apply)
-      }
-    case _ => Task.pure(Left(NotFound(id.ref)))
+    case Some(v: ElasticSearchView)               => clients.elasticSearch.searchRaw(query, Set(v.index), params).map(Right.apply)
+    case Some(agg: AggregateElasticSearchView[_]) => agg.queryableIndices.flatMap(runSearchForIndices(params, query))
+    case _                                        => Task.pure(Left(NotFound(id.ref)))
   }
+
+  private def runSearchForIndices(params: Uri.Query, query: Json)(indices: Set[String]): Task[Either[Rejection, Json]] =
+    indices match {
+      case indices if indices.isEmpty => Task.pure[Either[Rejection, Json]](Right(emptyEsList))
+      case indices                    => clients.elasticSearch.searchRaw(query, indices, params).map(Right.apply)
+    }
+}
+
+object ViewRoutes {
+  private[routes] final case class ProgressWrapper(offset: Offset)
+
+  type ListResults[A] = QueryResults[IdentifiedValue[A]]
+
+  private[routes] object ProgressWrapper {
+
+    val empty: ProgressWrapper = ProgressWrapper(NoOffset)
+
+    implicit val encoderProgress: Encoder[ProgressWrapper] =
+      Encoder
+        .instance[ProgressWrapper] {
+          case ProgressWrapper(NoOffset) =>
+            Json.obj("@type" -> nxv.NoProgress.prefix.asJson)
+          case ProgressWrapper(Sequence(value)) =>
+            Json.obj("@type" -> nxv.Sequential.prefix.asJson, nxv.offset.prefix -> value.asJson)
+          case ProgressWrapper(tm: TimeBasedUUID) =>
+            Json.obj("@type" -> nxv.TimeBased.prefix.asJson, nxv.offset.prefix -> tm.asInstant.asJson)
+          case _ => Json.obj()
+        }
+        .mapJson(_.addContext(progressCtxUri))
+
+  }
+
+  private[routes] implicit val encoderListResultsOffset: Encoder[ListResults[ProgressWrapper]] = {
+    implicit val progressEnc = ProgressWrapper.encoderProgress.mapJson(_.removeKeys("@context"))
+    qrsEncoderLowPrio[IdentifiedValue[ProgressWrapper]].mapJson(_.addContext(progressCtxUri))
+  }
+
+  private[routes] implicit val encoderListResultsStatistics: Encoder[ListResults[Statistics]] = {
+    implicit val statstisticsEnc = Statistics.statisticsEncoder.mapJson(_.removeKeys("@context"))
+    qrsEncoderLowPrio[IdentifiedValue[Statistics]].mapJson(_.addContext(statisticsCtxUri))
+  }
+
 }

--- a/src/test/resources/view/progress_projection_list.json
+++ b/src/test/resources/view/progress_projection_list.json
@@ -1,0 +1,20 @@
+{
+  "@context" : [
+    "https://bluebrain.github.io/nexus/contexts/search.json",
+    "https://bluebrain.github.io/nexus/contexts/resource.json",
+    "https://bluebrain.github.io/nexus/contexts/progress.json"
+  ],
+  "_total" : 2,
+  "_results" : [
+    {
+      "@id" : "https://bluebrain.github.io/nexus/vocabulary/defaultSparqlIndex",
+      "@type" : "TimeBased",
+      "offset" : "{timeOffset}"
+    },
+    {
+      "@id" : "https://bluebrain.github.io/nexus/vocabulary/defaultElasticSearchIndex",
+      "@type" : "Sequential",
+      "offset" : {seqOffset}
+    }
+  ]
+}

--- a/src/test/resources/view/statistics_projection_list.json
+++ b/src/test/resources/view/statistics_projection_list.json
@@ -1,0 +1,28 @@
+{
+  "@context": [
+    "https://bluebrain.github.io/nexus/contexts/search.json",
+    "https://bluebrain.github.io/nexus/contexts/resource.json",
+    "https://bluebrain.github.io/nexus/contexts/statistics.json"
+  ],
+  "_total": 2,
+  "_results": [
+    {
+      "@id": "https://bluebrain.github.io/nexus/vocabulary/defaultSparqlIndex",
+      "discardedEvents": 2,
+      "evaluatedEvents": 7,
+      "failedEvents": 1,
+      "processedEvents": 10,
+      "remainingEvents": 10,
+      "totalEvents": 20
+    },
+    {
+      "@id": "https://bluebrain.github.io/nexus/vocabulary/defaultElasticSearchIndex",
+      "discardedEvents": 0,
+      "evaluatedEvents": 11,
+      "failedEvents": 1,
+      "processedEvents": 12,
+      "remainingEvents": 1,
+      "totalEvents": 13
+    }
+  ]
+}

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorSpec.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.Props
+import akka.persistence.query.Sequence
 import akka.testkit.DefaultTimeout
 import ch.epfl.bluebrain.nexus.admin.client.types._
 import ch.epfl.bluebrain.nexus.commons.cache.OnKeyValueStoreChange
@@ -15,17 +16,20 @@ import ch.epfl.bluebrain.nexus.kg.cache._
 import ch.epfl.bluebrain.nexus.kg.config.AppConfig._
 import ch.epfl.bluebrain.nexus.kg.config.Settings
 import ch.epfl.bluebrain.nexus.kg.indexing.View
-import ch.epfl.bluebrain.nexus.kg.indexing.View.{ElasticSearchView, Filter, SparqlView}
+import ch.epfl.bluebrain.nexus.kg.indexing.View.CompositeView.Projection.{ElasticSearchProjection, SparqlProjection}
+import ch.epfl.bluebrain.nexus.kg.indexing.View.CompositeView.Source
+import ch.epfl.bluebrain.nexus.kg.indexing.View.{apply => _, _}
 import ch.epfl.bluebrain.nexus.kg.resources.OrganizationRef
 import ch.epfl.bluebrain.nexus.kg.resources.syntax._
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import ch.epfl.bluebrain.nexus.sourcing.projections.ProjectionProgress.OffsetProgress
 import ch.epfl.bluebrain.nexus.sourcing.projections.{ProjectionProgress, Projections, StreamSupervisor}
 import io.circe.Json
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.{Inspectors, Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 
@@ -38,7 +42,8 @@ class ProjectViewCoordinatorSpec
     with Eventually
     with ScalaFutures
     with IdiomaticMockito
-    with ArgumentMatchersSugar {
+    with ArgumentMatchersSugar
+    with Inspectors {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(15 second, 150 milliseconds)
 
@@ -51,35 +56,28 @@ class ProjectViewCoordinatorSpec
 
     val orgUuid = genUUID
     // format: off
-    val project = Project(genIri, "some-project", "some-org", None, genIri, genIri, Map.empty, genUUID, orgUuid, 1L, deprecated = false, Instant.EPOCH, creator, Instant.EPOCH, creator)
-    val project2 = Project(genIri, "some-project2", "some-org", None, genIri, genIri, Map.empty, genUUID, genUUID, 1L, deprecated = false, Instant.EPOCH, creator, Instant.EPOCH, creator)
-    val project2Updated = project2.copy(label = genString(), rev = 2L)
+    implicit val project           = Project(genIri, "some-project", "some-org", None, genIri, genIri, Map.empty, genUUID, orgUuid, 1L, deprecated = false, Instant.EPOCH, creator, Instant.EPOCH, creator)
+    val project2          = Project(genIri, "some-project2", "some-org", None, genIri, genIri, Map.empty, genUUID, genUUID, 1L, deprecated = false, Instant.EPOCH, creator, Instant.EPOCH, creator)
+    val project2Updated   = project2.copy(label = genString(), rev = 2L)
+    val view              = SparqlView(Filter(), true, project.ref, genIri, genUUID, 1L, deprecated = false)
+    val view2             = ElasticSearchView(Json.obj(), Filter(Set(genIri)), true, true, project.ref, genIri, genUUID, 1L, deprecated = false)
+    val view2Updated      = view2.copy(filter = view2.filter.copy(resourceSchemas = Set(genIri)), rev = 2L)
+    val view3             = SparqlView(Filter(), true, project2.ref, genIri, genUUID, 1L, deprecated = false)
+    val projection1       = ElasticSearchProjection("query", ElasticSearchView(Json.obj(), Filter(), false, false, project.ref, genIri, genUUID, 1L, false), Json.obj())
+    val projection2       = SparqlProjection("query2", SparqlView(Filter(), true, project.ref, genIri, genUUID, 1L, false))
+    val view4             = CompositeView(Source(Filter(Set(genIri)), true), Set(projection1, projection2), project.ref, genIri, genUUID, 1L, false)
     // format: on
-    val view = SparqlView(Filter(), true, project.ref, genIri, genUUID, 1L, deprecated = false)
-    val view2 =
-      ElasticSearchView(
-        Json.obj(),
-        Filter(Set(genIri)),
-        true,
-        true,
-        project.ref,
-        genIri,
-        genUUID,
-        1L,
-        deprecated = false
-      )
-    val view2Updated = view2.copy(filter = view2.filter.copy(resourceSchemas = Set(genIri)), rev = 2L)
-    val view3 =
-      SparqlView(Filter(), true, project2.ref, genIri, genUUID, 1L, deprecated = false)
 
-    val counterStart = new AtomicInteger(0)
-    val counterStop  = new AtomicInteger(0)
+    val counterStart            = new AtomicInteger(0)
+    val counterStartProjections = new AtomicInteger(0)
+    val counterStop             = new AtomicInteger(0)
 
     val coordinator1         = mock[StreamSupervisor[Task, ProjectionProgress]]
     val coordinator2         = mock[StreamSupervisor[Task, ProjectionProgress]]
     val coordinator2Updated  = mock[StreamSupervisor[Task, ProjectionProgress]]
     val coordinator3         = mock[StreamSupervisor[Task, ProjectionProgress]]
     val coordinator3Updated  = mock[StreamSupervisor[Task, ProjectionProgress]]
+    val coordinator4         = mock[StreamSupervisor[Task, ProjectionProgress]]
     implicit val projections = mock[Projections[Task, String]]
 
     coordinator1.stop() shouldReturn Task.unit
@@ -87,6 +85,7 @@ class ProjectViewCoordinatorSpec
     coordinator2Updated.stop() shouldReturn Task.unit
     coordinator3.stop() shouldReturn Task.unit
     coordinator3Updated.stop() shouldReturn Task.unit
+    coordinator4.stop() shouldReturn Task.unit
 
     val coordinatorProps = Props(
       new ProjectViewCoordinatorActor(viewCache) {
@@ -102,8 +101,19 @@ class ProjectViewCoordinatorSpec
           else if (v == view3 && proj == project2) coordinator3
           else if (v == view3.copy(rev = 2L) && proj == project2) coordinator3
           else if (v == view3.copy(rev = 2L) && proj == project2Updated && restartOffset) coordinator3Updated
+          else if (v == view4 && proj == project) coordinator4
           else throw new RuntimeException()
         }
+
+        override def startCoordinator(
+            view: CompositeView,
+            proj: Project,
+            restartOffsetViews: Set[SingleView]
+        ): StreamSupervisor[Task, ProjectionProgress] =
+          if (view == view4 && proj == project && restartOffsetViews == view4.projections.map(_.view)) {
+            counterStartProjections.incrementAndGet()
+            coordinator4
+          } else throw new RuntimeException()
 
         override def deleteViewIndices(view: View.IndexedView, project: Project): Task[Unit] = {
           counterStop.incrementAndGet()
@@ -112,6 +122,7 @@ class ProjectViewCoordinatorSpec
 
         override def onChange: OnKeyValueStoreChange[AbsoluteIri, View] =
           onViewChange(self)
+
       }
     )
 
@@ -130,70 +141,156 @@ class ProjectViewCoordinatorSpec
 
     projections.progress(any[String]) shouldReturn Task.pure(ProjectionProgress.NoProgress)
 
+    val currentStart     = new AtomicInteger(0)
+    val currentProjStart = new AtomicInteger(0)
+    val currentStop      = new AtomicInteger(0)
+
     "initialize projects" in {
       projectCache.replace(project).runToFuture.futureValue
       projectCache.replace(project2).runToFuture.futureValue
 
       coordinator.start(project).runToFuture.futureValue
-      eventually(counterStart.get shouldEqual 0)
+      eventually(counterStart.get shouldEqual currentStart.get)
 
       coordinator.start(project2).runToFuture.futureValue
-      eventually(counterStart.get shouldEqual 0)
+      eventually(counterStart.get shouldEqual currentStart.get)
     }
 
     "start view indexer when views are cached" in {
       viewCache.put(view2).runToFuture.futureValue
-      eventually(counterStart.get shouldEqual 1)
+      currentStart.incrementAndGet()
+      eventually(counterStart.get shouldEqual currentStart.get)
 
+      currentStart.incrementAndGet()
       viewCache.put(view).runToFuture.futureValue
-      eventually(counterStart.get shouldEqual 2)
+      eventually(counterStart.get shouldEqual currentStart.get)
 
+      currentStart.incrementAndGet()
       viewCache.put(view3).runToFuture.futureValue
-      eventually(counterStart.get shouldEqual 3)
+      eventually(counterStart.get shouldEqual currentStart.get)
+
+      currentStart.incrementAndGet()
+      viewCache.put(view4).runToFuture.futureValue
+      eventually(counterStart.get shouldEqual currentStart.get)
+
+      counterStartProjections.get shouldEqual currentProjStart.get
+      counterStop.get shouldEqual counterStop.get
+    }
+
+    "fetch statistics" in {
+      val progress: ProjectionProgress = OffsetProgress(Sequence(2L), 2L, 0L, 1L)
+      coordinator1.state() shouldReturn Task(Some(progress))
+      val result = coordinator.statistics(view).runToFuture.futureValue
+      result.processedEvents shouldEqual 2L
+      result.discardedEvents shouldEqual 0L
+      result.failedEvents shouldEqual 1L
+    }
+
+    "fetch projections statistics" in {
+      val progress: ProjectionProgress = OffsetProgress(Sequence(2L), 2L, 0L, 1L)
+      coordinator4.state() shouldReturn Task(Some(progress))
+      val result = coordinator.projectionsStatistic(view4).runToFuture.futureValue
+      result.total shouldEqual 2L
+      forAll(result.results.map(_.source.value)) { statistic =>
+        statistic.processedEvents shouldEqual 2L
+        statistic.discardedEvents shouldEqual 0L
+        statistic.failedEvents shouldEqual 1L
+      }
+    }
+
+    "fetch offset" in {
+      val progress: ProjectionProgress = OffsetProgress(Sequence(2L), 2L, 0L, 1L)
+      coordinator2.state() shouldReturn Task(Some(progress))
+      coordinator.offset(view2).runToFuture.futureValue shouldEqual Sequence(2L)
+    }
+
+    "fetch projections offset" in {
+      val progress: ProjectionProgress = OffsetProgress(Sequence(2L), 2L, 0L, 1L)
+      coordinator4.state() shouldReturn Task(Some(progress))
+      val result = coordinator.projectionsOffset(view4).runToFuture.futureValue
+      result.total shouldEqual 2L
+      forAll(result.results.map(_.source.value)) { offset =>
+        offset shouldEqual Sequence(2L)
+      }
+    }
+
+    "trigger manual view restart" in {
+      coordinator.restart(view)
+      currentStart.incrementAndGet()
+      eventually(coordinator1.stop() wasCalled once)
+      eventually(counterStart.get shouldEqual currentStart.get)
+      eventually(counterStop.get shouldEqual currentStop.get)
+      counterStartProjections.get shouldEqual currentProjStart.get
+    }
+
+    "trigger manual projections restart" in {
+      coordinator.restartProjections(view4)
+      currentProjStart.incrementAndGet()
+      eventually(coordinator4.stop() wasCalled once)
+      eventually(counterStartProjections.get shouldEqual currentProjStart.get)
+      counterStart.get shouldEqual currentStart.get
+      counterStop.get shouldEqual currentStop.get
     }
 
     "stop view when view is removed (deprecated) from the cache" in {
       viewCache.put(view.copy(deprecated = true)).runToFuture.futureValue
-      eventually(counterStop.get shouldEqual 1)
-      eventually(counterStart.get shouldEqual 3)
-      eventually(coordinator1.stop() wasCalled once)
+      currentStop.incrementAndGet()
+      eventually(coordinator1.stop() wasCalled twice)
+      eventually(counterStop.get shouldEqual currentStop.get)
+      eventually(counterStart.get shouldEqual currentStart.get)
+      counterStartProjections.get shouldEqual currentProjStart.get
     }
 
     "stop old elasticsearch view start new view when current view updated" in {
       viewCache.put(view2Updated).runToFuture.futureValue
-      eventually(counterStop.get shouldEqual 2)
-      eventually(counterStart.get shouldEqual 4)
+      currentStop.incrementAndGet()
+      eventually(counterStop.get shouldEqual currentStop.get)
+
+      currentStart.incrementAndGet()
       eventually(coordinator2.stop() wasCalled once)
+      eventually(counterStart.get shouldEqual currentStart.get)
+
+      counterStartProjections.get shouldEqual currentProjStart.get
     }
 
     "stop old sparql view start new view when current view updated" in {
       viewCache.put(view3.copy(rev = 2L)).runToFuture.futureValue
-      eventually(counterStop.get shouldEqual 3)
-      eventually(counterStart.get shouldEqual 5)
+      currentStop.incrementAndGet()
+      eventually(counterStop.get shouldEqual currentStop.get)
+
+      currentStart.incrementAndGet()
       eventually(coordinator3.stop() wasCalled once)
+      eventually(counterStart.get shouldEqual currentStart.get)
+      counterStartProjections.get shouldEqual currentProjStart.get
     }
 
     "stop all related views when organization is deprecated" in {
       coordinator.stop(OrganizationRef(orgUuid)).runToFuture.futureValue
-      eventually(counterStop.get shouldEqual 3)
-      eventually(counterStart.get shouldEqual 5)
       eventually(coordinator2Updated.stop() wasCalled once)
+      eventually(counterStop.get shouldEqual currentStop.get)
+      eventually(counterStart.get shouldEqual currentStart.get)
+      counterStartProjections.get shouldEqual currentProjStart.get
     }
 
     "restart all related views when project changes" in {
       projectCache.replace(project2Updated).runToFuture.futureValue
       coordinator.change(project2Updated, project2).runToFuture.futureValue
-      eventually(counterStop.get shouldEqual 4)
-      eventually(counterStart.get shouldEqual 6)
+      currentStop.incrementAndGet()
+      eventually(counterStop.get shouldEqual currentStop.get)
+      currentStart.incrementAndGet()
+      eventually(counterStart.get shouldEqual currentStart.get)
       eventually(coordinator3.stop() wasCalled twice)
+      counterStartProjections.get shouldEqual currentProjStart.get
     }
 
     "stop related views when project is deprecated" in {
       projectCache.replace(project2Updated.copy(deprecated = true)).runToFuture.futureValue
       coordinator.stop(project2Updated.ref).runToFuture.futureValue
-      eventually(counterStop.get shouldEqual 4)
-      eventually(counterStart.get shouldEqual 6)
+      eventually(counterStop.get shouldEqual currentStop.get)
+      eventually(counterStart.get shouldEqual currentStart.get)
       eventually(coordinator3Updated.stop() wasCalled once)
+      counterStartProjections.get shouldEqual currentProjStart.get
     }
+
   }
 }

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/async/ProjectViewCoordinatorSpec.scala
@@ -215,7 +215,7 @@ class ProjectViewCoordinatorSpec
     }
 
     "trigger manual view restart" in {
-      coordinator.restart(view)
+      coordinator.restart(view).runToFuture.futureValue
       currentStart.incrementAndGet()
       eventually(coordinator1.stop() wasCalled once)
       eventually(counterStart.get shouldEqual currentStart.get)
@@ -224,7 +224,7 @@ class ProjectViewCoordinatorSpec
     }
 
     "trigger manual projections restart" in {
-      coordinator.restartProjections(view4)
+      coordinator.restartProjections(view4).runToFuture.futureValue
       currentProjStart.incrementAndGet()
       eventually(coordinator4.stop() wasCalled once)
       eventually(counterStartProjections.get shouldEqual currentProjStart.get)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/RoutesFixtures.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/kg/routes/RoutesFixtures.scala
@@ -74,7 +74,9 @@ trait RoutesFixtures extends TestHelper with Resources {
 
   val defaultEsView = ElasticSearchView(Json.obj(), Filter(), false, true, projectRef, nxv.defaultElasticSearchIndex.value, genUUID, 1L, false)
   val defaultSparqlView = SparqlView.default(projectRef)
-  val compositeView = CompositeView(Source(Filter(), includeMetadata = false), Set(SparqlProjection("", defaultSparqlView), ElasticSearchProjection("", defaultEsView, Json.obj())), projectRef, genIri, genUUID, 1L, deprecated = false)
+  val sparqlProjection = SparqlProjection("", defaultSparqlView)
+  val elasticSearchProjection = ElasticSearchProjection("", defaultEsView, Json.obj())
+  val compositeView = CompositeView(Source(Filter(), includeMetadata = false), Set(sparqlProjection, elasticSearchProjection), projectRef, genIri, genUUID, 1L, deprecated = false)
   // format: on
 
   implicit val finalProject = projectMeta.copy(apiMappings = projectMeta.apiMappings ++ defaultPrefixMapping)


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/728
Fixes https://github.com/BlueBrain/nexus/issues/917

- Adds the progress GET/DELETE endpoint for each view, each projection and all projections (`_`)
- Adds the statistics GET endpoint for each view, each projection and all projections (`_`)
- Adds the endpoint to query all projections at the same time (`_`)
- Minor bug fixing
